### PR TITLE
reverting to version without openPx

### DIFF
--- a/contracts/GammaPool.sol
+++ b/contracts/GammaPool.sol
@@ -150,9 +150,9 @@ contract GammaPool is IGammaPool, GammaPoolERC4626 {
     }
 
     function loan(uint256 tokenId) external virtual override view returns (uint256 id, address poolId,
-        uint256[] memory tokensHeld, uint256 initLiquidity, uint256 liquidity, uint256 lpTokens, uint256 openPx, uint256 rateIndex) {
+        uint256[] memory tokensHeld, uint256 initLiquidity, uint256 liquidity, uint256 lpTokens, uint256 rateIndex) {
         GammaPoolStorage.Loan storage _loan = GammaPoolStorage.store().loans[tokenId];
-        return (_loan.id, _loan.poolId, _loan.tokensHeld, _loan.initLiquidity, _loan.liquidity, _loan.lpTokens, _loan.openPx, _loan.rateIndex);
+        return (_loan.id, _loan.poolId, _loan.tokensHeld, _loan.initLiquidity, _loan.liquidity, _loan.lpTokens, _loan.rateIndex);
     }
 
     function increaseCollateral(uint256 tokenId) external virtual override returns(uint256[] memory tokensHeld) {

--- a/contracts/interfaces/IGammaPool.sol
+++ b/contracts/interfaces/IGammaPool.sol
@@ -6,7 +6,7 @@ interface IGammaPool {
     event PoolUpdated(uint256 lpTokenBalance, uint256 lpTokenBorrowed, uint256 lastBlockNumber, uint256 accFeeIndex,
         uint256 lastFeeIndex, uint256 lpTokenBorrowedPlusInterest, uint256 lpInvariant, uint256 lpBorrowedInvariant);
     event LoanCreated(address indexed caller, uint256 tokenId);
-    event LoanUpdated(uint256 indexed tokenId, uint256[] tokensHeld, uint256 heldLiquidity, uint256 liquidity, uint256 openPx, uint256 rateIndex);
+    event LoanUpdated(uint256 indexed tokenId, uint256[] tokensHeld, uint256 heldLiquidity, uint256 liquidity, uint256 lpTokens, uint256 rateIndex);
 
     function cfmm() external view returns(address);
     function protocolId() external view returns(uint24);
@@ -41,7 +41,7 @@ interface IGammaPool {
 
     //Long Gamma
     function createLoan() external returns(uint tokenId);
-    function loan(uint256 tokenId) external view returns (uint256 id, address poolId, uint256[] memory tokensHeld, uint256 initLiquidity, uint256 liquidity, uint256 lpTokens, uint256 openPx, uint256 rateIndex);
+    function loan(uint256 tokenId) external view returns (uint256 id, address poolId, uint256[] memory tokensHeld, uint256 initLiquidity, uint256 liquidity, uint256 lpTokens, uint256 rateIndex);
     function increaseCollateral(uint256 tokenId) external returns(uint256[] memory tokensHeld);
     function decreaseCollateral(uint256 tokenId, uint256[] calldata amounts, address to) external returns(uint256[] memory tokensHeld);
     function borrowLiquidity(uint256 tokenId, uint256 lpTokens) external returns(uint256[] memory amounts);

--- a/contracts/interfaces/strategies/base/ILongStrategy.sol
+++ b/contracts/interfaces/strategies/base/ILongStrategy.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 interface ILongStrategy {
 
-    event LoanUpdated(uint256 indexed tokenId, uint256[] tokensHeld, uint256 heldLiquidity, uint256 liquidity, uint256 openPx, uint256 rateIndex);
+    event LoanUpdated(uint256 indexed tokenId, uint256[] tokensHeld, uint256 heldLiquidity, uint256 liquidity, uint256 lpTokens, uint256 rateIndex);
 
     function _increaseCollateral(uint256 tokenId) external returns(uint256[] memory);
     function _decreaseCollateral(uint256 tokenId, uint256[] calldata amounts, address to) external returns(uint256[] memory tokensHeld);

--- a/contracts/libraries/AddressCalculator.sol
+++ b/contracts/libraries/AddressCalculator.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 library AddressCalculator {
     // update this value if GammaPool gets updated
-    bytes32 internal constant GAMMA_POOL_INIT_CODE_HASH = 0xea55fd6b491611699d47d549596807d306583f030b574cffc818f18c64fc10df;
+    bytes32 internal constant GAMMA_POOL_INIT_CODE_HASH = 0x5b4e2ea5c335bf3eb17163d6c88bd2235be1e5d2e8323b1dbf2c022e2e12545c;
 
     function getGammaPoolKey(address cfmm, uint24 protocol) internal pure returns(bytes32) {
         return keccak256(abi.encode(cfmm, protocol));

--- a/contracts/libraries/storage/GammaPoolStorage.sol
+++ b/contracts/libraries/storage/GammaPoolStorage.sol
@@ -17,7 +17,6 @@ library GammaPoolStorage {
         uint256 initLiquidity;
         uint256 liquidity;
         uint256 lpTokens;
-        uint256 openPx;
         uint256 rateIndex;
     }
 
@@ -129,7 +128,6 @@ library GammaPoolStorage {
             initLiquidity: 0,
             liquidity: 0,
             lpTokens: 0,
-            openPx: 0,
             rateIndex: _store.accFeeIndex
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Core smart contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",

--- a/test/GammaPool.test.ts
+++ b/test/GammaPool.test.ts
@@ -232,7 +232,7 @@ describe("GammaPool", function () {
       expect(res0.events[0].args.tokensHeld[1]).to.eq(tokenId);
       expect(res0.events[0].args.heldLiquidity).to.eq(10);
       expect(res0.events[0].args.liquidity).to.eq(11);
-      expect(res0.events[0].args.openPx).to.eq(12);
+      expect(res0.events[0].args.lpTokens).to.eq(12);
       expect(res0.events[0].args.rateIndex).to.eq(13);
 
       const res1 = await (
@@ -244,7 +244,7 @@ describe("GammaPool", function () {
       expect(res1.events[0].args.tokensHeld[1]).to.eq(200);
       expect(res1.events[0].args.heldLiquidity).to.eq(20);
       expect(res1.events[0].args.liquidity).to.eq(21);
-      expect(res1.events[0].args.openPx).to.eq(22);
+      expect(res1.events[0].args.lpTokens).to.eq(22);
       expect(res1.events[0].args.rateIndex).to.eq(23);
 
       const res2 = await (await gammaPool.borrowLiquidity(tokenId, 300)).wait();
@@ -254,7 +254,7 @@ describe("GammaPool", function () {
       expect(res2.events[0].args.tokensHeld[1]).to.eq(300);
       expect(res2.events[0].args.heldLiquidity).to.eq(30);
       expect(res2.events[0].args.liquidity).to.eq(31);
-      expect(res2.events[0].args.openPx).to.eq(32);
+      expect(res2.events[0].args.lpTokens).to.eq(32);
       expect(res2.events[0].args.rateIndex).to.eq(33);
 
       const res3 = await (await gammaPool.repayLiquidity(tokenId, 400)).wait();
@@ -264,7 +264,7 @@ describe("GammaPool", function () {
       expect(res3.events[0].args.tokensHeld[1]).to.eq(10);
       expect(res3.events[0].args.heldLiquidity).to.eq(tokenId);
       expect(res3.events[0].args.liquidity).to.eq(400);
-      expect(res3.events[0].args.openPx).to.eq(42);
+      expect(res3.events[0].args.lpTokens).to.eq(42);
       expect(res3.events[0].args.rateIndex).to.eq(43);
 
       const res4 = await (
@@ -276,7 +276,7 @@ describe("GammaPool", function () {
       expect(res4.events[0].args.tokensHeld[1]).to.eq(600);
       expect(res4.events[0].args.heldLiquidity).to.eq(tokenId);
       expect(res4.events[0].args.liquidity).to.eq(51);
-      expect(res4.events[0].args.openPx).to.eq(52);
+      expect(res4.events[0].args.lpTokens).to.eq(52);
       expect(res4.events[0].args.rateIndex).to.eq(53);
     });
   });


### PR DESCRIPTION
moving openPx to events, will never be checked in other part of the application and uses up too much gas to keep track of