### PR TITLE
setting tokens to correct order in factory

### DIFF
--- a/contracts/GammaPoolFactory.sol
+++ b/contracts/GammaPoolFactory.sol
@@ -68,7 +68,7 @@ contract GammaPoolFactory is AbstractGammaPoolFactory {
 
         pool = cloneDeterministic(implementation, key);
 
-        IGammaPool(pool).initialize(cfmm, tokens);
+        IGammaPool(pool).initialize(cfmm, _tokens);
 
         getPool[key] = pool;
         allPools.push(pool);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Core smart contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",


### PR DESCRIPTION
tokens in gammapool were set in the opposite order by gammapool factory. They're supposed to match the same order as in uniswap