### PR TITLE
adding batch liquidation interface + unit test and function to get al…

### DIFF
--- a/contracts/base/GammaPool.sol
+++ b/contracts/base/GammaPool.sol
@@ -55,8 +55,30 @@ abstract contract GammaPool is IGammaPool, GammaPoolERC4626 {
         return(s.CFMM_RESERVES, s.lastCFMMInvariant, s.lastCFMMTotalSupply);
     }
 
-    function getRates() external virtual override view returns(uint256 borrowRate, uint256 accFeeIndex, uint256 lastFeeIndex, uint256 lastCFMMFeeIndex, uint256 lastBlockNumber) {
-        return(s.borrowRate, s.accFeeIndex, s.lastFeeIndex, s.lastCFMMFeeIndex, s.LAST_BLOCK_NUMBER);
+    function getRates() external virtual override view returns(uint256 accFeeIndex, uint256 lastBlockNumber) {
+        return(s.accFeeIndex, s.LAST_BLOCK_NUMBER);
+    }
+
+    function getPoolData() external virtual override view returns(PoolData memory data) {
+        data.protocolId = protocolId;
+        data.longStrategy = longStrategy;
+        data.shortStrategy = shortStrategy;
+        data.liquidationStrategy = liquidationStrategy;
+        data.cfmm = s.cfmm;
+        data.LAST_BLOCK_NUMBER = s.LAST_BLOCK_NUMBER;
+        data.factory = s.factory;
+        data.LP_TOKEN_BALANCE = s.LP_TOKEN_BALANCE;
+        data.LP_TOKEN_BORROWED = s.LP_TOKEN_BORROWED;
+        data.LP_TOKEN_BORROWED_PLUS_INTEREST = s.LP_TOKEN_BORROWED_PLUS_INTEREST;
+        data.BORROWED_INVARIANT = s.BORROWED_INVARIANT;
+        data.LP_INVARIANT = s.LP_INVARIANT;
+        data.accFeeIndex = s.accFeeIndex;
+        data.lastCFMMInvariant = s.lastCFMMInvariant;
+        data.lastCFMMTotalSupply = s.lastCFMMTotalSupply;
+        data.totalSupply = s.totalSupply;
+        data.tokens = s.tokens;
+        data.TOKEN_BALANCE = s.TOKEN_BALANCE;
+        data.CFMM_RESERVES = s.CFMM_RESERVES;
     }
 
     /*****SHORT*****/
@@ -119,5 +141,9 @@ abstract contract GammaPool is IGammaPool, GammaPoolERC4626 {
 
     function liquidateWithLP(uint256 tokenId) external override virtual returns(uint256[] memory refund) {
         return abi.decode(callStrategy(liquidationStrategy, abi.encodeWithSelector(ILiquidationStrategy._liquidateWithLP.selector, tokenId)), (uint256[]));
+    }
+
+    function batchLiquidations(uint256[] calldata tokenIds) external override virtual returns(uint256[] memory refund) {
+        return abi.decode(callStrategy(liquidationStrategy, abi.encodeWithSelector(ILiquidationStrategy._batchLiquidations.selector, tokenIds)), (uint256[]));
     }
 }

--- a/contracts/interfaces/IGammaPool.sol
+++ b/contracts/interfaces/IGammaPool.sol
@@ -8,6 +8,39 @@ interface IGammaPool {
     event LoanCreated(address indexed caller, uint256 tokenId);
     event LoanUpdated(uint256 indexed tokenId, uint128[] tokensHeld, uint256 liquidity, uint256 lpTokens, uint256 rateIndex);
 
+    struct PoolData {
+        uint16 protocolId;
+        address longStrategy;
+        address shortStrategy;
+        address liquidationStrategy;
+
+        address cfmm;
+        uint96 LAST_BLOCK_NUMBER;//uint96
+        address factory;
+
+        // LP Tokens
+        uint256 LP_TOKEN_BALANCE;//LP Tokens in GS, LP_TOKEN_TOTAL = LP_TOKEN_BALANCE + LP_TOKEN_BORROWED_PLUS_INTEREST
+        uint256 LP_TOKEN_BORROWED;//LP Tokens that have been borrowed (Principal)
+        uint256 LP_TOKEN_BORROWED_PLUS_INTEREST;//LP Tokens that have been borrowed (principal) plus interest in LP Tokens
+
+        // 1x256 bits, Invariants
+        uint128 BORROWED_INVARIANT;
+        uint128 LP_INVARIANT;//Invariant from LP Tokens, TOTAL_INVARIANT = BORROWED_INVARIANT + LP_INVARIANT
+
+        // 2x256 bits, rates
+        uint96 accFeeIndex;//uint96, max 7.9% trillion
+        uint128 lastCFMMInvariant;//uint128
+        uint256 lastCFMMTotalSupply;
+
+        // ERC20 fields
+        uint256 totalSupply;
+
+        // tokens and balances
+        address[] tokens;
+        uint128[] TOKEN_BALANCE;
+        uint128[] CFMM_RESERVES; //keeps track of price of CFMM at time of update
+    }
+
     function initialize(address cfmm, address[] calldata tokens) external;
 
     function cfmm() external view returns(address);
@@ -21,7 +54,8 @@ interface IGammaPool {
     function getPoolBalances() external virtual view returns(uint128[] memory tokenBalances, uint256 lpTokenBalance, uint256 lpTokenBorrowed,
         uint256 lpTokenBorrowedPlusInterest, uint256 borrowedInvariant, uint256 lpInvariant);
     function getCFMMBalances() external virtual view returns(uint128[] memory cfmmReserves, uint256 cfmmInvariant, uint256 cfmmTotalSupply);
-    function getRates() external virtual view returns(uint256 borrowRate, uint256 accFeeIndex, uint256 lastFeeIndex, uint256 lastCFMMFeeIndex, uint256 lastBlockNumber);
+    function getRates() external virtual view returns(uint256 accFeeIndex, uint256 lastBlockNumber);
+    function getPoolData() external virtual view returns(PoolData memory data);
 
     function validateCFMM(address[] calldata _tokens, address _cfmm) external view returns(address[] memory tokens);
 
@@ -42,4 +76,5 @@ interface IGammaPool {
     function rebalanceCollateral(uint256 tokenId, int256[] calldata deltas) external returns(uint128[] memory tokensHeld);
     function liquidate(uint256 tokenId, bool isRebalance, int256[] calldata deltas) external virtual returns(uint256[] memory refund);
     function liquidateWithLP(uint256 tokenId) external virtual returns(uint256[] memory refund);
+    function batchLiquidations(uint256[] calldata tokenIds) external virtual returns(uint256[] memory refund);
 }

--- a/contracts/interfaces/strategies/base/ILiquidationStrategy.sol
+++ b/contracts/interfaces/strategies/base/ILiquidationStrategy.sol
@@ -7,4 +7,5 @@ interface ILiquidationStrategy {
 
     function _liquidate(uint256 tokenId, bool isRebalance, int256[] calldata deltas) external virtual returns(uint256[] memory refund);
     function _liquidateWithLP(uint256 tokenId) external virtual returns(uint256[] memory refund);
+    function _batchLiquidations(uint256[] calldata tokenIds) external virtual returns(uint256[] memory refund);
 }

--- a/contracts/libraries/LibStorage.sol
+++ b/contracts/libraries/LibStorage.sol
@@ -19,39 +19,27 @@ library LibStorage {
 
     struct Storage {
         // 2x256 bits
-        uint96 yieldTWAP;
         address cfmm;
-        uint96 cumulativeYield;
+        uint96 LAST_BLOCK_NUMBER;//uint96
         address factory;
-
-        // 1x64 bits
-        uint32 cumulativeTime;
-        uint32 lastBlockTimestamp;
+        uint96 unlocked;//should be 1
 
         // LP Tokens
-        uint256 LP_TOKEN_BALANCE;//LP Tokens in GS, LP_TOKEN_TOTAL = LP_TOKEN_BALANCE + LP_TOKEN_BORROWED_PLUS_INTEREST (will remove this)
+        uint256 LP_TOKEN_BALANCE;//LP Tokens in GS, LP_TOKEN_TOTAL = LP_TOKEN_BALANCE + LP_TOKEN_BORROWED_PLUS_INTEREST
         uint256 LP_TOKEN_BORROWED;//LP Tokens that have been borrowed (Principal)
-        uint256 LP_TOKEN_BORROWED_PLUS_INTEREST;//(LP Tokens that have been borrowed (principal) plus interest in LP Tokens)
+        uint256 LP_TOKEN_BORROWED_PLUS_INTEREST;//LP Tokens that have been borrowed (principal) plus interest in LP Tokens
 
         // 1x256 bits, Invariants
         uint128 BORROWED_INVARIANT;
         uint128 LP_INVARIANT;//Invariant from LP Tokens, TOTAL_INVARIANT = BORROWED_INVARIANT + LP_INVARIANT
 
-        // 1x256 bits, rates
-        uint80 borrowRate;//uint72, max 120% million
-        uint80 lastFeeIndex;//uint72, max 120% million
+        // 2x256 bits, rates
         uint96 accFeeIndex;//uint96, max 7.9% trillion
-
-        // 2x256 bits, CFMM values
-        uint48 LAST_BLOCK_NUMBER;//uint48
-        uint80 lastCFMMFeeIndex;//uint72, max 120% million
         uint128 lastCFMMInvariant;//uint128
         uint256 lastCFMMTotalSupply;
 
         /// @dev The ID of the next loan that will be minted. Skips 0
         uint256 nextId;//should be 1
-
-        uint256 unlocked;//should be 1
 
         // ERC20 fields
         uint256 totalSupply;
@@ -64,7 +52,7 @@ library LibStorage {
         // tokens and balances
         address[] tokens;
         uint128[] TOKEN_BALANCE;
-        uint128[] CFMM_RESERVES;
+        uint128[] CFMM_RESERVES; //keeps track of price of CFMM at time of update
     }
 
     error Initialized();
@@ -77,10 +65,8 @@ library LibStorage {
         self.cfmm = cfmm;
         self.tokens = tokens;
 
-        self.lastFeeIndex = 10**18;
         self.accFeeIndex = 10**18;
         self.LAST_BLOCK_NUMBER = uint48(block.number);
-        self.lastCFMMFeeIndex = 10**18;
 
         self.nextId = 1;
         self.unlocked = 1;

--- a/contracts/test/strategies/TestLiquidationStrategy.sol
+++ b/contracts/test/strategies/TestLiquidationStrategy.sol
@@ -24,4 +24,14 @@ contract TestLiquidationStrategy is ILiquidationStrategy  {
         emit LoanUpdated(tokenId, tokensHeld, refund[0], refund[1], 10);
     }
 
+    function _batchLiquidations(uint256[] calldata tokenIds) external override virtual returns(uint256[] memory refund) {
+        uint128[] memory tokensHeld = new uint128[](2);
+        tokensHeld[0] = 11;
+        tokensHeld[1] = 12;
+        refund = new uint256[](2);
+        refund[0] = 13;
+        refund[1] = 14;
+        emit LoanUpdated(tokenIds[0], tokensHeld, refund[0], refund[1], 15);
+        emit LoanUpdated(tokenIds[1], tokensHeld, refund[0], refund[1], 15);
+    }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -25,7 +25,15 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
 // Go to https://hardhat.org/config/ to learn more
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.4",
+  solidity: {
+    version: "0.8.4",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
   networks: {
     hardhat: {
       chainId: 31337

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "0.1.36",
+  "version": "0.2.0",
   "description": "Core smart contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",


### PR DESCRIPTION
1. Added batch liquidation function to interface of gammapool and its implementation requesting from liquidation strategy and a unit test for it
2. Added function to read all relevant data from gammapool, to avoid making multiple calls to it in the future
3. removed unneeded storage variables (borrowRate, lastCFMMFeeIndex, lastFeeIndex) and other variables related to twap calculation that we no longer need. Kept CFMM_RESERVES since it's the price of the pool at the last time it was updated.