### PR TITLE
creating IBaseStrategy and IBaseLongStrategy and moving LoanUpdated event there

### DIFF
--- a/contracts/interfaces/strategies/base/IBaseLongStrategy.sol
+++ b/contracts/interfaces/strategies/base/IBaseLongStrategy.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.4;
+
+import "./IBaseStrategy.sol";
+
+interface IBaseLongStrategy is IBaseStrategy {
+    event LoanUpdated(uint256 indexed tokenId, uint128[] tokensHeld, uint256 liquidity, uint256 lpTokens, uint256 rateIndex);
+}

--- a/contracts/interfaces/strategies/base/IBaseStrategy.sol
+++ b/contracts/interfaces/strategies/base/IBaseStrategy.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.4;
+
+interface IBaseStrategy {
+    event PoolUpdated(uint256 lpTokenBalance, uint256 lpTokenBorrowed, uint256 lastBlockNumber, uint256 accFeeIndex,
+        uint256 lpTokenBorrowedPlusInterest, uint256 lpInvariant, uint256 borrowedInvariant);
+}

--- a/contracts/interfaces/strategies/base/ILiquidationStrategy.sol
+++ b/contracts/interfaces/strategies/base/ILiquidationStrategy.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.4;
 
-interface ILiquidationStrategy {
+import "./IBaseLongStrategy.sol";
 
-    event LoanUpdated(uint256 indexed tokenId, uint128[] tokensHeld, uint256 liquidity, uint256 lpTokens, uint256 rateIndex);
+interface ILiquidationStrategy is IBaseLongStrategy {
+
     event Liquidation(uint256 indexed tokenId, uint256 collateral, uint256 liquidity, uint8 typ);
     event BatchLiquidations(uint256 liquidityTotal, uint256 collateralTotal, uint256 lpTokensPrincipalTotal, uint128[] tokensHeldTotal, uint256[] tokenIds);
     event WriteDown(uint256 indexed tokenId, uint256 writeDownAmt);

--- a/contracts/interfaces/strategies/base/ILongStrategy.sol
+++ b/contracts/interfaces/strategies/base/ILongStrategy.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.4;
 
-interface ILongStrategy {
+import "./IBaseLongStrategy.sol";
 
-    event LoanUpdated(uint256 indexed tokenId, uint128[] tokensHeld, uint256 liquidity, uint256 lpTokens, uint256 rateIndex);
+interface ILongStrategy is IBaseLongStrategy {
 
     function _getLatestCFMMReserves() external view returns(uint256[] memory cfmmReserves);
     function _increaseCollateral(uint256 tokenId) external returns(uint128[] memory tokensHeld);

--- a/contracts/interfaces/strategies/base/IShortStrategy.sol
+++ b/contracts/interfaces/strategies/base/IShortStrategy.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.4;
 
-interface IShortStrategy {
+import "./IBaseStrategy.sol";
+
+interface IShortStrategy is IBaseStrategy {
     function _depositNoPull(address to) external returns(uint256 shares);
     function _withdrawNoPull(address to) external returns(uint256 assets);
     function _withdrawReserves(address to) external returns(uint256[] memory reserves, uint256 assets);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Core smart contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",


### PR DESCRIPTION
created IBaseStrategy and IBaseLongStrategy to hold PoolUpdated event and LoanUpdated event respectively. That's because every strategy needs to inherit that event and LongStrategy and LiquidationStrategy need to inherit LoanUpdated event.