### PR TITLE
add address parameter to getLatestCFMMReserves() function in GammaPool

### DIFF
--- a/contracts/base/GammaPool.sol
+++ b/contracts/base/GammaPool.sol
@@ -103,7 +103,7 @@ abstract contract GammaPool is IGammaPool, GammaPoolERC4626, Transfers {
     /*****LONG*****/
 
     function getLatestCFMMReserves() external virtual override view returns(uint256[] memory cfmmReserves) {
-        return ILongStrategy(longStrategy)._getLatestCFMMReserves();
+        return ILongStrategy(longStrategy)._getLatestCFMMReserves(s.cfmm);
     }
 
     function createLoan() external virtual override returns(uint256 tokenId) {

--- a/contracts/interfaces/strategies/base/ILongStrategy.sol
+++ b/contracts/interfaces/strategies/base/ILongStrategy.sol
@@ -5,7 +5,7 @@ import "./IBaseLongStrategy.sol";
 
 interface ILongStrategy is IBaseLongStrategy {
 
-    function _getLatestCFMMReserves() external view returns(uint256[] memory cfmmReserves);
+    function _getLatestCFMMReserves(address cfmm) external view returns(uint256[] memory cfmmReserves);
     function _increaseCollateral(uint256 tokenId) external returns(uint128[] memory tokensHeld);
     function _decreaseCollateral(uint256 tokenId, uint256[] calldata amounts, address to) external returns(uint128[] memory tokensHeld);
     function _borrowLiquidity(uint256 tokenId, uint256 lpTokens) external returns(uint256[] memory amounts);

--- a/contracts/test/strategies/TestLongStrategy.sol
+++ b/contracts/test/strategies/TestLongStrategy.sol
@@ -5,7 +5,7 @@ import "../../interfaces/strategies/base/ILongStrategy.sol";
 
 contract TestLongStrategy is ILongStrategy {
 
-    function _getLatestCFMMReserves() external override pure returns(uint256[] memory cfmmReserves) {
+    function _getLatestCFMMReserves(address) external override pure returns(uint256[] memory cfmmReserves) {
         cfmmReserves = new uint256[](2);
         cfmmReserves[0] = 3;
         cfmmReserves[1] = 4;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Core smart contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",


### PR DESCRIPTION
added address paramter to getLatestCFMMReserves() function in ILonStrategy when calling from GammaPool so that the function can be run independent of the state of the GammaPool.