### PR TITLE
Add Storage Parameters to GammaPool

### DIFF
--- a/contracts/GammaPoolFactory.sol
+++ b/contracts/GammaPoolFactory.sol
@@ -81,7 +81,7 @@ contract GammaPoolFactory is AbstractGammaPoolFactory {
         address implementation = getProtocol[_protocolId];
 
         // check GammaPool can be created with this implementation
-        (address[] memory _tokensOrdered, uint8[] memory _decimals) = IGammaPool(implementation).validateCFMM(_tokens, _cfmm, _data);
+        (address[] memory _tokensOrdered, uint8[] memory _decimals, uint256[] memory _weights) = IGammaPool(implementation).validateCFMM(_tokens, _cfmm, _data);
 
         // calculate unique identifier of GammaPool that will also be used as salt for instantiating the proxy contract address
         bytes32 key = AddressCalculator.getGammaPoolKey(_cfmm, _protocolId);
@@ -91,7 +91,7 @@ contract GammaPoolFactory is AbstractGammaPoolFactory {
         // instantiate GammaPool proxy contract address for protocol's implementation contract using unique key as salt for the pool's address
         pool = cloneDeterministic(implementation, key);
 
-        IGammaPool(pool).initialize(_cfmm, _tokensOrdered, _decimals); // initialize GammaPool's state variables
+        IGammaPool(pool).initialize(_cfmm, _tokensOrdered, _decimals, _weights); // initialize GammaPool's state variables
 
         getPool[key] = pool; // map unique key to new instance of GammaPool
         allPools.push(pool); // store new GammaPool instance in an array

--- a/contracts/base/GammaPool.sol
+++ b/contracts/base/GammaPool.sol
@@ -41,11 +41,11 @@ abstract contract GammaPool is IGammaPool, GammaPoolERC4626, Refunds {
     }
 
     /// @dev See {IGammaPool-initialize}
-    function initialize(address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals) external virtual override {
+    function initialize(address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals, uint256[] calldata _weights) external virtual override {
         if(msg.sender != factory) // only factory is allowed to initialize
             revert Forbidden();
 
-        s.initialize(factory, _cfmm, _tokens, _decimals);
+        s.initialize(factory, _cfmm, _tokens, _decimals, _weights);
     }
 
     /// @dev See {IGammaPool-cfmm}
@@ -56,6 +56,11 @@ abstract contract GammaPool is IGammaPool, GammaPoolERC4626, Refunds {
     /// @dev See {IGammaPool-tokens}
     function tokens() external virtual override view returns(address[] memory) {
         return s.tokens;
+    }
+
+    /// @dev See {IGammaPool-weights}
+    function weights() external virtual override view returns(uint256[] memory) {
+        return s.weights;
     }
 
     /// @dev See {IGammaPool-vaultImplementation}
@@ -102,6 +107,7 @@ abstract contract GammaPool is IGammaPool, GammaPoolERC4626, Refunds {
         data.totalSupply = s.totalSupply;
         data.decimals = s.decimals;
         data.tokens = s.tokens;
+        data.weights = s.weights;
         data.TOKEN_BALANCE = s.TOKEN_BALANCE;
         data.CFMM_RESERVES = s.CFMM_RESERVES;
     }

--- a/contracts/interfaces/IGammaPool.sol
+++ b/contracts/interfaces/IGammaPool.sol
@@ -58,6 +58,8 @@ interface IGammaPool is IGammaPoolEvents {
         address[] tokens;
         /// @dev Decimals of CFMM tokens, indices match tokens[] array
         uint8[] decimals;
+        /// @dev Normalized weights of CFMM tokens, indices match tokens[] array
+        uint256[] weights;
         /// @dev Amounts of ERC20 tokens from the CFMM held as collateral in the GammaPool. Equals to the sum of all tokensHeld[] quantities in all loans
         uint128[] TOKEN_BALANCE;
         /// @dev Amounts of ERC20 tokens from the CFMM held in the CFMM as reserve quantities. Used to log prices in the CFMM during updates to the GammaPool
@@ -68,7 +70,8 @@ interface IGammaPool is IGammaPoolEvents {
     /// @param _cfmm - address of CFMM GammaPool is for
     /// @param _tokens - ERC20 tokens of CFMM
     /// @param _decimals - decimals of CFMM tokens, indices must match _tokens[] array
-    function initialize(address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals) external;
+    /// @param _weights - normalized weights of CFMM tokens, indices must match _tokens[] array
+    function initialize(address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals, uint256[] calldata _weights) external;
 
     /// @dev cfmm - address of CFMM this GammaPool is for
     function cfmm() external view returns(address);
@@ -78,6 +81,9 @@ interface IGammaPool is IGammaPoolEvents {
 
     /// @dev ERC20 tokens of CFMM
     function tokens() external view returns(address[] memory);
+
+    /// @dev Weights of CFMM tokens
+    function weights() external view returns(uint256[] memory);
 
     /// @dev factory - address of factory contract that instantiated this GammaPool
     function factory() external view returns(address);
@@ -122,7 +128,7 @@ interface IGammaPool is IGammaPoolEvents {
     /// @param _data - custom struct containing additional information used to verify the `_cfmm`
     /// @return _tokensOrdered - tokens ordered to match the same order as in CFMM
     /// @return _decimals - decimal places of tokens in CFMM. Their index matches _tokensOrdered.
-    function validateCFMM(address[] calldata _tokens, address _cfmm, bytes calldata _data) external view returns(address[] memory _tokensOrdered, uint8[] memory _decimals);
+    function validateCFMM(address[] calldata _tokens, address _cfmm, bytes calldata _data) external view returns(address[] memory _tokensOrdered, uint8[] memory _decimals, uint256[] memory _weights);
 
     // Short Gamma
 

--- a/contracts/libraries/LibStorage.sol
+++ b/contracts/libraries/LibStorage.sol
@@ -85,6 +85,8 @@ library LibStorage {
         address[] tokens;
         /// @dev Decimals of tokens in CFMM, indices match tokens[] array
         uint8[] decimals;
+        /// @dev Normalized weights of tokens in CFMM, indices match tokens[] array. Weights should be normalized to 1e18
+        uint256[] weights;
         /// @dev Amounts of ERC20 tokens from the CFMM held as collateral in the GammaPool. Equals to the sum of all tokensHeld[] quantities in all loans
         uint128[] TOKEN_BALANCE;
         /// @dev Amounts of ERC20 tokens from the CFMM held in the CFMM as reserve quantities. Used to log prices quoted by the CFMM during updates to the GammaPool
@@ -99,7 +101,7 @@ library LibStorage {
     /// @param _cfmm - address of CFMM this GammaPool is for
     /// @param _tokens - tokens of CFMM this GammaPool is for
     /// @param _decimals -decimals of the tokens of the CFMM the GammaPool is for, indices must match tokens array
-    function initialize(Storage storage self, address _factory, address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals) internal {
+    function initialize(Storage storage self, address _factory, address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals, uint256[] calldata _weights) internal {
         if(self.factory != address(0)) // cannot initialize twice
             revert Initialized();
 
@@ -107,6 +109,7 @@ library LibStorage {
         self.cfmm = _cfmm;
         self.tokens = _tokens;
         self.decimals = _decimals;
+        self.weights = _weights;
 
         self.lastCFMMFeeIndex = 1e18;
         self.accFeeIndex = 1e18; // initialized as 1 with 18 decimal places

--- a/contracts/test/TestGammaPool.sol
+++ b/contracts/test/TestGammaPool.sol
@@ -26,12 +26,15 @@ contract TestGammaPool is GammaPool {
         s.LP_TOKEN_BALANCE = uint128(IERC20(s.cfmm).balanceOf(address(this)));
     }
 
-    function validateCFMM(address[] calldata _tokens, address _cfmm, bytes calldata _data) external virtual override view returns(address[] memory _tokensOrdered, uint8[] memory _decimals) {
+    function validateCFMM(address[] calldata _tokens, address _cfmm, bytes calldata _data) external virtual override view returns(address[] memory _tokensOrdered, uint8[] memory _decimals, uint256[] memory _weights) {
         params memory decoded = abi.decode(_data, (params));
         require(decoded.cfmm == _cfmm, "Validation");
         _tokensOrdered = _tokens;
         _decimals = new uint8[](_tokens.length);
         _decimals[0] = 18;
         _decimals[1] = 18;
+        _weights = new uint256[](_tokens.length);
+        _weights[0] = 5e17;
+        _weights[1] = 5e17;
     }
 }


### PR DESCRIPTION
Adding `weights` as a storage parameter to the GammaPool.

This will allow Balancer implementations to query the `AppStorage` rather than querying external contracts for these values.