### PR TITLE
fix unit tests for rate params store

### DIFF
--- a/contracts/interfaces/rates/IRateModel.sol
+++ b/contracts/interfaces/rates/IRateModel.sol
@@ -5,7 +5,12 @@ pragma solidity >=0.8.0;
 /// @author Daniel D. Alcarraz (https://github.com/0xDanr)
 /// @notice Interface of contract that saves and retrieves interest rate model parameters
 interface IRateModel {
+    /// @dev Function to validate interest rate model parameters
+    /// @param _data - bytes parameters containing interest rate model parameters
+    /// @return validation - true if parameters passed validation
     function validateParameters(bytes calldata _data) external view returns(bool);
 
+    /// @dev Gets address of contract containing parameters for interest rate model
+    /// @return address - address of smart contract that stores interest rate parameters
     function rateParamsStore() external view returns(address);
 }

--- a/contracts/rates/AbstractRateModel.sol
+++ b/contracts/rates/AbstractRateModel.sol
@@ -29,18 +29,11 @@ abstract contract AbstractRateModel is IRateModel {
     /// @return utilizationRate - utilization rate used to calculate the borrow rate
     function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant) internal virtual view returns(uint256, uint256);
 
-    /// @dev See {IRateModel-validateParameters}
-    function validateParameters(bytes calldata _data) external override virtual view returns(bool) {
-        return false;
-    }
-
     /// @dev See {IRateModel-rateParamsStore}
     function rateParamsStore() public override virtual view returns(address) {
         return _rateParamsStore();
     }
 
     /// @dev Return contract holding rate parameters
-    function _rateParamsStore() internal virtual view returns(address) {
-        return address(0);
-    }
+    function _rateParamsStore() internal virtual view returns(address);
 }

--- a/contracts/rates/LinearKinkedRateModel.sol
+++ b/contracts/rates/LinearKinkedRateModel.sol
@@ -52,4 +52,9 @@ abstract contract LinearKinkedRateModel is AbstractRateModel, ILinearKinkedRateM
             borrowRate = baseRate + slope1 + variableRate;
         }
     }
+
+    /// @dev See {IRateModel-validateParameters}.
+    function validateParameters(bytes calldata _data) external override view returns(bool) {
+        return true;
+    }
 }

--- a/contracts/test/rates/TestLinearKinkedRateModel.sol
+++ b/contracts/test/rates/TestLinearKinkedRateModel.sol
@@ -2,8 +2,12 @@
 pragma solidity 0.8.17;
 
 import "../../rates/LinearKinkedRateModel.sol";
+import "../../rates/storage/AbstractRateParamsStore.sol";
 
-contract TestLinearKinkedRateModel is LinearKinkedRateModel {
+contract TestLinearKinkedRateModel is LinearKinkedRateModel, AbstractRateParamsStore {
+
+    address public owner;
+    address private paramsStore;
 
     constructor(uint64 _baseRate, uint64 _optimalUtilRate, uint64 _slope1, uint64 _slope2)
         LinearKinkedRateModel(_baseRate, _optimalUtilRate, _slope1, _slope2){
@@ -11,5 +15,17 @@ contract TestLinearKinkedRateModel is LinearKinkedRateModel {
 
     function testCalcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant) public virtual view returns(uint256 borrowRate) {
         (borrowRate,) = calcBorrowRate(lpInvariant, borrowedInvariant);
+    }
+
+    function _rateParamsStoreOwner() internal virtual override view returns(address) {
+        return owner;
+    }
+
+    function setRateParamsStore(address _paramsStore) public virtual {
+        paramsStore = _paramsStore;
+    }
+
+    function _rateParamsStore() internal override virtual view returns(address) {
+        return paramsStore;
     }
 }

--- a/contracts/test/rates/TestLogDerivativeRateModel.sol
+++ b/contracts/test/rates/TestLogDerivativeRateModel.sol
@@ -26,7 +26,7 @@ contract TestLogDerivativeRateModel is LogDerivativeRateModel, AbstractRateParam
         paramsStore = _paramsStore;
     }
 
-    function rateParamsStore() public override(AbstractRateModel, IRateModel) virtual view returns(address) {
+    function _rateParamsStore() internal override virtual view returns(address) {
         return paramsStore;
     }
 }

--- a/contracts/test/strategies/base/TestBaseShortStrategy.sol
+++ b/contracts/test/strategies/base/TestBaseShortStrategy.sol
@@ -25,6 +25,10 @@ abstract contract TestBaseShortStrategy is ShortStrategy {
         return 2252571;
     }
 
+    function validateParameters(bytes calldata _data) external override view returns(bool) {
+        return false;
+    }
+
     function mintToDevs(uint256 lastFeeIndex, uint256 lastCFMMIndex) internal override virtual {
     }
 

--- a/contracts/test/strategies/base/TestBaseStrategy.sol
+++ b/contracts/test/strategies/base/TestBaseStrategy.sol
@@ -35,6 +35,10 @@ contract TestBaseStrategy is BaseStrategy {
         return 2252571;
     }
 
+    function validateParameters(bytes calldata _data) external override view returns(bool) {
+        return false;
+    }
+
     function getParameters() public virtual view returns(address factory, address cfmm, address[] memory tokens, uint16 protocolId) {
         factory = _factory;
         cfmm = s.cfmm;

--- a/contracts/test/strategies/base/TestLiquidationStrategy.sol
+++ b/contracts/test/strategies/base/TestLiquidationStrategy.sol
@@ -248,4 +248,8 @@ contract TestLiquidationStrategy is LiquidationStrategy {
         reserves = new uint128[](2);
         (reserves[0], reserves[1],) = TestCFMM(cfmm).getReserves();
     }
+
+    function validateParameters(bytes calldata _data) external override view returns(bool) {
+        return false;
+    }
 }

--- a/contracts/test/strategies/base/TestLongStrategy.sol
+++ b/contracts/test/strategies/base/TestLongStrategy.sol
@@ -316,4 +316,8 @@ contract TestLongStrategy is LongStrategy {
         reserves = new uint128[](2);
         (reserves[0], reserves[1],) = TestCFMM(cfmm).getReserves();
     }
+
+    function validateParameters(bytes calldata _data) external override view returns(bool) {
+        return false;
+    }
 }

--- a/contracts/test/strategies/external/TestExternalBaseLongStrategy.sol
+++ b/contracts/test/strategies/external/TestExternalBaseLongStrategy.sol
@@ -43,6 +43,10 @@ abstract contract TestExternalBaseLongStrategy is ExternalBaseStrategy {
         return 10;
     }
 
+    function validateParameters(bytes calldata _data) external override view returns(bool) {
+        return false;
+    }
+
     function externalSwapFee() internal view override virtual returns(uint256) {
         return swapFee;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Core smart contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",


### PR DESCRIPTION
-rate params store change broke unit tests in implementations, best solution was to update v1-core inheritance tree of the rate params store
-adding natspecs to rate paramst store contract and rate model interface