### PR TITLE
use canLiquidate instead of checkMargin

### DIFF
--- a/contracts/test/strategies/base/TestLiquidationStrategy.sol
+++ b/contracts/test/strategies/base/TestLiquidationStrategy.sol
@@ -140,7 +140,7 @@ contract TestLiquidationStrategy is SingleLiquidationStrategy, BatchLiquidationS
     }
 
     function testCanLiquidate(uint256 collateral, uint256 liquidity) external virtual {
-        checkMargin(collateral, liquidity);
+        if(!canLiquidate(liquidity, collateral)) revert HasMargin();
     }
 
     function testUpdateLoan(uint256 tokenId) external virtual {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Core smart contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",


### PR DESCRIPTION
update BaseLiquidationStrategy to use canLiquidate instead of checkMargin when calling getLiquidatableLoan