### PR TITLE
add function _repayLiquiditySetRatio

### DIFF
--- a/contracts/base/GammaPool.sol
+++ b/contracts/base/GammaPool.sol
@@ -343,8 +343,13 @@ abstract contract GammaPool is IGammaPool, GammaPoolERC4626, Refunds {
     }
 
     /// @dev See {IGammaPool-repayLiquidity}
-    function repayLiquidity(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256 collateralId, address to, uint256[] calldata ratio) external virtual override returns(uint256 liquidityPaid, uint256[] memory amounts) {
-        return abi.decode(callStrategy(repayStrategy, abi.encodeWithSelector(IRepayStrategy._repayLiquidity.selector, tokenId, liquidity, fees, collateralId, to, ratio)), (uint256, uint256[]));
+    function repayLiquidity(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256 collateralId, address to) external virtual override returns(uint256 liquidityPaid, uint256[] memory amounts) {
+        return abi.decode(callStrategy(repayStrategy, abi.encodeWithSelector(IRepayStrategy._repayLiquidity.selector, tokenId, liquidity, fees, collateralId, to)), (uint256, uint256[]));
+    }
+
+    /// @dev See {IGammaPool-repayLiquiditySetRatio}
+    function repayLiquiditySetRatio(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256[] calldata ratio) external virtual override returns(uint256 liquidityPaid, uint256[] memory amounts) {
+        return abi.decode(callStrategy(repayStrategy, abi.encodeWithSelector(IRepayStrategy._repayLiquidity.selector, tokenId, liquidity, fees, ratio)), (uint256, uint256[]));
     }
 
     /// @dev See {IGammaPool-repayLiquidityWithLP}

--- a/contracts/interfaces/IGammaPool.sol
+++ b/contracts/interfaces/IGammaPool.sol
@@ -380,10 +380,18 @@ interface IGammaPool is IGammaPoolEvents, IGammaPoolERC20Events, IRateModel {
     /// @param fees - fee on transfer for tokens[i]. Send empty array if no token in pool has fee on transfer or array of zeroes
     /// @param collateralId - index of collateral token + 1
     /// @param to - if repayment type requires withdrawal, the address that will receive the funds. Otherwise can be zero address
-    /// @param ratio - ratio to rebalance collateral after repaying liquidity
     /// @return liquidityPaid - liquidity amount that has been repaid
     /// @return amounts - collateral amounts consumed in repaying liquidity debt
-    function repayLiquidity(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256 collateralId, address to, uint256[] calldata ratio) external returns(uint256 liquidityPaid, uint256[] memory amounts);
+    function repayLiquidity(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256 collateralId, address to) external returns(uint256 liquidityPaid, uint256[] memory amounts);
+
+    /// @dev Repay liquidity debt of loan identified by tokenId, debt is repaid using available collateral in loan
+    /// @param tokenId - unique id identifying loan
+    /// @param liquidity - liquidity debt being repaid, capped at actual liquidity owed. Can't repay more than you owe
+    /// @param fees - fee on transfer for tokens[i]. Send empty array if no token in pool has fee on transfer or array of zeroes
+    /// @param ratio - weights of collateral after repaying liquidity
+    /// @return liquidityPaid - liquidity amount that has been repaid
+    /// @return amounts - collateral amounts consumed in repaying liquidity debt
+    function repayLiquiditySetRatio(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256[] calldata ratio) external returns(uint256 liquidityPaid, uint256[] memory amounts);
 
     /// @dev Repay liquidity debt of loan identified by tokenId, using CFMM LP token
     /// @param tokenId - unique id identifying loan

--- a/contracts/interfaces/strategies/lending/IRepayStrategy.sol
+++ b/contracts/interfaces/strategies/lending/IRepayStrategy.sol
@@ -22,8 +22,17 @@ interface IRepayStrategy is ILongStrategy {
     /// @param fees - fee on transfer for tokens[i]. Send empty array if no token in pool has fee on transfer or array of zeroes
     /// @param collateralId - index of collateral token to rebalance to + 1
     /// @param to - if repayment type requires withdrawal, the address that will receive the funds. Otherwise can be zero address
+    /// @return liquidityPaid - liquidity amount that has been repaid
+    /// @return amounts - collateral amounts consumed in repaying liquidity debt
+    function _repayLiquidity(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256 collateralId, address to) external returns(uint256 liquidityPaid, uint256[] memory amounts);
+
+
+    /// @dev Repay liquidity debt of loan identified by tokenId, debt is repaid using available collateral in loan
+    /// @param tokenId - unique id identifying loan
+    /// @param liquidity - liquidity debt being repaid, capped at actual liquidity owed. Can't repay more than you owe
+    /// @param fees - fee on transfer for tokens[i]. Send empty array if no token in pool has fee on transfer or array of zeroes
     /// @param ratio - weights of collateral after repaying liquidity
     /// @return liquidityPaid - liquidity amount that has been repaid
     /// @return amounts - collateral amounts consumed in repaying liquidity debt
-    function _repayLiquidity(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256 collateralId, address to, uint256[] calldata ratio) external returns(uint256 liquidityPaid, uint256[] memory amounts);
+    function _repayLiquiditySetRatio(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256[] calldata ratio) external returns(uint256 liquidityPaid, uint256[] memory amounts);
 }

--- a/contracts/test/strategies/TestRepayStrategy2.sol
+++ b/contracts/test/strategies/TestRepayStrategy2.sol
@@ -17,7 +17,18 @@ contract TestRepayStrategy2 is IRepayStrategy {
         emit LoanUpdated(tokenId, heldTokens, uint128(liquidity), uint128(40), uint8(collateralId), uint96(20), TX_TYPE.REPAY_LIQUIDITY_WITH_LP);
     }
 
-    function _repayLiquidity(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256 collateralId, address to, uint256[] calldata ratio) external override returns(uint256 liquidityPaid, uint256[] memory amounts){
+    function _repayLiquidity(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256 collateralId, address to) external override returns(uint256 liquidityPaid, uint256[] memory amounts){
+        liquidityPaid = tokenId;
+        amounts = new uint256[](2);
+        amounts[0] = 9;
+        amounts[1] = 10;
+        uint128[] memory heldTokens = new uint128[](2);
+        heldTokens[0] = 9;
+        heldTokens[1] = 10;
+        emit LoanUpdated(tokenId, heldTokens, uint128(liquidity), uint128(40 + fees.length), fees[0], uint96(fees[1]), TX_TYPE.REPAY_LIQUIDITY);
+    }
+
+    function _repayLiquiditySetRatio(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256[] calldata ratio) external override returns(uint256 liquidityPaid, uint256[] memory amounts){
         liquidityPaid = tokenId;
         amounts = new uint256[](2);
         amounts[0] = 9;

--- a/contracts/test/strategies/base/TestLongStrategy.sol
+++ b/contracts/test/strategies/base/TestLongStrategy.sol
@@ -329,9 +329,9 @@ contract TestLongStrategy is RepayStrategy, BorrowStrategy {
         return false;
     }
 
-    function testUpdatePayableLoan(uint256 tokenId, uint256 payLiquidity, uint256[] calldata ratio) external virtual {
+    function testUpdatePayableLoan(uint256 tokenId, uint256 payLiquidity) external virtual {
         LibStorage.Loan storage _loan = _getLoan(tokenId);
-        (uint256 loanLiquidity, int256[] memory deltas) = updatePayableLoan(_loan, payLiquidity, ratio);
+        (uint256 loanLiquidity, int256[] memory deltas) = updatePayableLoan(_loan, payLiquidity, true);
         uint256 delta0 = deltas.length > 0 ? uint256(deltas[0]) : 0;
         uint256 delta1 = deltas.length > 1 ? uint256(deltas[1]) : 0;
         emit LiquidityAndDeltas(loanLiquidity, delta0, delta1, deltas.length);
@@ -354,5 +354,8 @@ contract TestLongStrategy is RepayStrategy, BorrowStrategy {
     }
 
     function _repayLiquidityWithLP(uint256 tokenId, uint256 payLiquidity, uint256 collateralId, address to) external virtual override returns(uint256 liquidityPaid) {
+    }
+
+    function _repayLiquiditySetRatio(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256[] calldata ratio) external override virtual returns(uint256 liquidityPaid, uint256[] memory amounts){
     }
 }

--- a/contracts/test/strategies/base/TestRepayStrategy.sol
+++ b/contracts/test/strategies/base/TestRepayStrategy.sol
@@ -324,11 +324,6 @@ contract TestRepayStrategy is RepayStrategy, BorrowStrategy {
         return false;
     }
 
-    function testUpdatePayableLoan(uint256 tokenId, uint256 payLiquidity, uint256[] calldata ratio) external virtual {
-        LibStorage.Loan storage _loan = _getLoan(tokenId);
-        updatePayableLoan(_loan, payLiquidity, ratio);
-    }
-
     function _calcMaxCollateral(int256[] memory deltas, uint128[] memory tokensHeld, uint128[] memory reserves) internal virtual override view returns(uint256 collateral) {
         return calcInvariant(address(0), tokensHeld);
     }
@@ -345,6 +340,9 @@ contract TestRepayStrategy is RepayStrategy, BorrowStrategy {
         deltas[1] = 100;
     }
 
-    function _repayLiquidity(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256 collateralId, address to, uint256[] calldata ratio) external override returns(uint256 liquidityPaid, uint256[] memory amounts){
+    function _repayLiquidity(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256 collateralId, address to) external override virtual returns(uint256 liquidityPaid, uint256[] memory amounts){
+    }
+
+    function _repayLiquiditySetRatio(uint256 tokenId, uint256 liquidity, uint256[] calldata fees, uint256[] calldata ratio) external override virtual returns(uint256 liquidityPaid, uint256[] memory amounts){
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Core smart contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",

--- a/test/strategies/LongStrategy.test.ts
+++ b/test/strategies/LongStrategy.test.ts
@@ -436,7 +436,7 @@ describe("LongStrategy", function () {
       await ethers.provider.send("hardhat_mine", ["0x100"]);
 
       const resp = await (
-        await strategy.testUpdatePayableLoan(tokenId, liquidity, [])
+        await strategy.testUpdatePayableLoan(tokenId, liquidity)
       ).wait();
 
       const evt = resp.events[0].args;
@@ -499,7 +499,7 @@ describe("LongStrategy", function () {
       await ethers.provider.send("hardhat_mine", ["0x100"]);
 
       const resp = await (
-        await strategy.testUpdatePayableLoan(tokenId, liquidity.mul(2), [])
+        await strategy.testUpdatePayableLoan(tokenId, liquidity.mul(2))
       ).wait();
 
       const evt = resp.events[0].args;
@@ -566,7 +566,7 @@ describe("LongStrategy", function () {
       await ethers.provider.send("hardhat_mine", ["0x100"]);
 
       const resp = await (
-        await strategy.testUpdatePayableLoan(tokenId, liquidity.mul(2), [])
+        await strategy.testUpdatePayableLoan(tokenId, liquidity.mul(2))
       ).wait();
 
       const evt = resp.events[0].args;
@@ -575,7 +575,7 @@ describe("LongStrategy", function () {
       expect(evt.liquidity).to.eq(loan2.liquidity);
       expect(evt.delta0).to.eq(0);
       expect(evt.delta1).to.eq(0); // Deltas for Close Keep Ratio
-      expect(evt.deltaLen).to.eq(2);
+      expect(evt.deltaLen).to.eq(0);
     });
   });
 


### PR DESCRIPTION
Changed _repayLiquidity to not include ratio in RepayStrategy
Instead added function _repayLiquiditySetRatio in RepayStrategy that takes into account repayment that also sets the ratio of collateral
Added access to the GammaPool to call _repayLiquiditySetRatio and updated _repayLiquidity to not include ratio
Updated unit tests.