### PR TITLE
initLiquidity exclude orig fees

### DIFF
--- a/contracts/strategies/base/BaseBorrowStrategy.sol
+++ b/contracts/strategies/base/BaseBorrowStrategy.sol
@@ -101,7 +101,7 @@ abstract contract BaseBorrowStrategy is BaseLongStrategy {
         mintOrigFeeToDevs(liquidityBorrowed, borrowedInvariant + s.LP_INVARIANT);
 
         // Calculate borrowed liquidity invariant including origination fee
-        liquidityBorrowed = liquidityBorrowed + convertLPToInvariant(lpTokens, lastCFMMInvariant, lastCFMMTotalSupply);
+        liquidityBorrowed = liquidityBorrowed + liquidityBorrowedExFee;
 
         // Add liquidity invariant borrowed including origination fee to total pool liquidity invariant borrowed
         borrowedInvariant = borrowedInvariant + liquidityBorrowed;
@@ -122,10 +122,10 @@ abstract contract BaseBorrowStrategy is BaseLongStrategy {
 
         // Update loan's total liquidity debt and principal amounts
         uint256 initLiquidity = _loan.initLiquidity;
-        _loan.px = updateLoanPrice(liquidityBorrowed, getCurrentCFMMPrice(), initLiquidity, _loan.px);
+        _loan.px = updateLoanPrice(liquidityBorrowedExFee, getCurrentCFMMPrice(), initLiquidity, _loan.px);
         liquidity = _loan.liquidity + liquidityBorrowed;
         _loan.liquidity = uint128(liquidity);
-        _loan.initLiquidity = uint128(initLiquidity + liquidityBorrowed);
+        _loan.initLiquidity = uint128(initLiquidity + liquidityBorrowedExFee);
         _loan.lpTokens = _loan.lpTokens + lpTokens;
     }
 

--- a/contracts/test/strategies/base/TestBorrowStrategy.sol
+++ b/contracts/test/strategies/base/TestBorrowStrategy.sol
@@ -238,13 +238,13 @@ contract TestBorrowStrategy is BorrowStrategy {
         s.LP_TOKEN_BORROWED_PLUS_INTEREST = s.LP_TOKEN_BORROWED_PLUS_INTEREST + lpTokenInterest;
     }
 
-    function getLoanChangeData(uint256 tokenId) public virtual view returns(uint256 loanLiquidity, uint256 loanLpTokens,
-        uint256 loanPx, uint256 borrowedInvariant, uint256 lpInvariant, uint256 totalInvariant,
+    function getLoanChangeData(uint256 tokenId) public virtual view returns(uint256 loanLiquidity, uint256 initLiquidity,
+        uint256 loanLpTokens, uint256 loanPx, uint256 borrowedInvariant, uint256 lpInvariant, uint256 totalInvariant,
         uint256 lpTokenBorrowed, uint256 lpTokenBalance, uint256 lpTokenBorrowedPlusInterest,
         uint256 lpTokenTotal, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply) {
         LibStorage.Loan storage _loan = _getLoan(tokenId);
 
-        return(_loan.liquidity, _loan.lpTokens, _loan.px,
+        return(_loan.liquidity, _loan.initLiquidity, _loan.lpTokens, _loan.px,
         s.BORROWED_INVARIANT, s.LP_INVARIANT, (s.BORROWED_INVARIANT + s.LP_INVARIANT),
         s.LP_TOKEN_BORROWED, s.LP_TOKEN_BALANCE, s.LP_TOKEN_BORROWED_PLUS_INTEREST,
         (s.LP_TOKEN_BALANCE + s.LP_TOKEN_BORROWED_PLUS_INTEREST), s.lastCFMMInvariant, s.lastCFMMTotalSupply);

--- a/contracts/test/strategies/base/TestLongStrategy.sol
+++ b/contracts/test/strategies/base/TestLongStrategy.sol
@@ -234,13 +234,13 @@ contract TestLongStrategy is RepayStrategy, BorrowStrategy {
         s.LP_TOKEN_BORROWED_PLUS_INTEREST = s.LP_TOKEN_BORROWED_PLUS_INTEREST + lpTokenInterest;
     }
 
-    function getLoanChangeData(uint256 tokenId) public virtual view returns(uint256 loanLiquidity, uint256 loanLpTokens,
-        uint256 loanPx, uint256 borrowedInvariant, uint256 lpInvariant, uint256 totalInvariant,
+    function getLoanChangeData(uint256 tokenId) public virtual view returns(uint256 loanLiquidity, uint256 initLiquidity,
+        uint256 loanLpTokens, uint256 loanPx, uint256 borrowedInvariant, uint256 lpInvariant, uint256 totalInvariant,
         uint256 lpTokenBorrowed, uint256 lpTokenBalance, uint256 lpTokenBorrowedPlusInterest,
         uint256 lpTokenTotal, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply) {
         LibStorage.Loan storage _loan = _getLoan(tokenId);
 
-        return(_loan.liquidity, _loan.lpTokens, _loan.px,
+        return(_loan.liquidity, _loan.initLiquidity, _loan.lpTokens, _loan.px,
             s.BORROWED_INVARIANT, s.LP_INVARIANT, (s.BORROWED_INVARIANT + s.LP_INVARIANT),
             s.LP_TOKEN_BORROWED, s.LP_TOKEN_BALANCE, s.LP_TOKEN_BORROWED_PLUS_INTEREST,
             (s.LP_TOKEN_BALANCE + s.LP_TOKEN_BORROWED_PLUS_INTEREST), s.lastCFMMInvariant, s.lastCFMMTotalSupply);

--- a/contracts/test/strategies/base/TestRepayStrategy.sol
+++ b/contracts/test/strategies/base/TestRepayStrategy.sol
@@ -229,13 +229,13 @@ contract TestRepayStrategy is RepayStrategy, BorrowStrategy {
         s.LP_TOKEN_BORROWED_PLUS_INTEREST = s.LP_TOKEN_BORROWED_PLUS_INTEREST + lpTokenInterest;
     }
 
-    function getLoanChangeData(uint256 tokenId) public virtual view returns(uint256 loanLiquidity, uint256 loanLpTokens,
-        uint256 loanPx, uint256 borrowedInvariant, uint256 lpInvariant, uint256 totalInvariant,
+    function getLoanChangeData(uint256 tokenId) public virtual view returns(uint256 loanLiquidity, uint256 initLiquidity,
+        uint256 loanLpTokens, uint256 loanPx, uint256 borrowedInvariant, uint256 lpInvariant, uint256 totalInvariant,
         uint256 lpTokenBorrowed, uint256 lpTokenBalance, uint256 lpTokenBorrowedPlusInterest,
         uint256 lpTokenTotal, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply) {
         LibStorage.Loan storage _loan = _getLoan(tokenId);
 
-        return(_loan.liquidity, _loan.lpTokens, _loan.px,
+        return(_loan.liquidity, _loan.initLiquidity, _loan.lpTokens, _loan.px,
         s.BORROWED_INVARIANT, s.LP_INVARIANT, (s.BORROWED_INVARIANT + s.LP_INVARIANT),
         s.LP_TOKEN_BORROWED, s.LP_TOKEN_BALANCE, s.LP_TOKEN_BORROWED_PLUS_INTEREST,
         (s.LP_TOKEN_BALANCE + s.LP_TOKEN_BORROWED_PLUS_INTEREST), s.lastCFMMInvariant, s.lastCFMMTotalSupply);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "description": "Core smart contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",

--- a/test/strategies/LongStrategy.test.ts
+++ b/test/strategies/LongStrategy.test.ts
@@ -1390,6 +1390,7 @@ describe("LongStrategy", function () {
       await (await strategy.testOpenLoan(tokenId, lpTokens)).wait();
       const res2 = await strategy.getLoanChangeData(tokenId);
       expect(res2.loanPx).to.equal(ONE);
+      expect(res2.initLiquidity).to.equal(liquidity);
       expect(res2.loanLiquidity).to.equal(liquidity);
       expect(res2.loanLpTokens).to.equal(lpTokens);
       expect(res2.borrowedInvariant).to.equal(liquidity);
@@ -1413,10 +1414,11 @@ describe("LongStrategy", function () {
       const expNewPx = updateLoanPrice(
         liquidity1,
         ONE.mul(2),
-        res2.loanLiquidity,
+        res2.initLiquidity,
         res2.loanPx
       );
       expect(res3.loanPx).to.equal(expNewPx);
+      expect(res3.initLiquidity).to.equal(liquidity.add(liquidity1));
       expect(res3.loanLiquidity).to.equal(liquidity.add(liquidity1));
       expect(res3.loanLpTokens).to.equal(lpTokens.add(lpTokens1));
       expect(res3.borrowedInvariant).to.equal(liquidity.add(liquidity1));
@@ -1472,6 +1474,7 @@ describe("LongStrategy", function () {
       const fee = liquidity.mul(10).div(10000);
       const feeLP = lpTokens.mul(10).div(10000);
       expect(res2.loanPx).to.equal(ONE);
+      expect(res2.initLiquidity).to.equal(liquidity);
       expect(res2.loanLiquidity).to.equal(liquidity.add(fee));
       expect(res2.loanLpTokens).to.equal(lpTokens);
       expect(res2.borrowedInvariant).to.equal(liquidity.add(fee));
@@ -1497,12 +1500,13 @@ describe("LongStrategy", function () {
       const feeLP1 = feeLP.add(lpTokens1.mul(10).div(10000));
 
       const expNewPx = updateLoanPrice(
-        liquidity1.add(fee1).sub(fee),
+        liquidity1,
         ONE.mul(3),
-        res2.loanLiquidity,
+        res2.initLiquidity,
         res2.loanPx
       );
       expect(res3.loanPx).to.equal(expNewPx);
+      expect(res3.initLiquidity).to.equal(liquidity.add(liquidity1));
       expect(res3.loanLiquidity).to.equal(liquidity.add(liquidity1).add(fee1));
       expect(res3.loanLpTokens).to.equal(lpTokens.add(lpTokens1));
       expect(res3.borrowedInvariant).to.equal(
@@ -1572,6 +1576,7 @@ describe("LongStrategy", function () {
       const fee = liquidity.mul(10).div(10000);
       const feeLP = lpTokens.mul(10).div(10000);
       expect(res2.loanPx).to.equal(ONE);
+      expect(res2.initLiquidity).to.equal(liquidity);
       expect(res2.loanLiquidity).to.equal(liquidity.add(fee));
       expect(res2.loanLpTokens).to.equal(lpTokens);
       expect(res2.borrowedInvariant).to.equal(liquidity.add(fee));
@@ -1614,6 +1619,7 @@ describe("LongStrategy", function () {
       await (await strategy.testOpenLoan(tokenId, lpTokens)).wait();
       const res2 = await strategy.getLoanChangeData(tokenId);
       expect(res2.loanPx).to.equal(ONE.mul(5));
+      expect(res2.initLiquidity).to.equal(liquidity);
       expect(res2.loanLiquidity).to.equal(liquidity);
       expect(res2.loanLpTokens).to.equal(lpTokens);
       expect(res2.borrowedInvariant).to.equal(liquidity);
@@ -1637,10 +1643,11 @@ describe("LongStrategy", function () {
       const expNewPx = updateLoanPrice(
         liquidity1,
         ONE.mul(7),
-        res2.loanLiquidity,
+        res2.initLiquidity,
         res2.loanPx
       );
       expect(res3.loanPx).to.equal(expNewPx);
+      expect(res3.initLiquidity).to.equal(liquidity.add(liquidity1));
       expect(res3.loanLiquidity).to.equal(liquidity.add(liquidity1));
       expect(res3.loanLpTokens).to.equal(lpTokens.add(lpTokens1));
       expect(res3.borrowedInvariant).to.equal(liquidity.add(liquidity1));
@@ -1693,6 +1700,7 @@ describe("LongStrategy", function () {
       await (await strategy.testOpenLoan(tokenId, lpTokens)).wait();
       const res2 = await strategy.getLoanChangeData(tokenId);
       expect(res2.loanPx).to.equal(ONE.mul(9));
+      expect(res2.initLiquidity).to.equal(liquidity);
       expect(res2.loanLiquidity).to.equal(liquidity);
       expect(res2.loanLpTokens).to.equal(lpTokens);
       expect(res2.borrowedInvariant).to.equal(liquidity);
@@ -1712,6 +1720,7 @@ describe("LongStrategy", function () {
       await (await strategy.testPayLoan(tokenId, liquidity.div(2))).wait();
       const res4 = await strategy.getLoanChangeData(tokenId);
       expect(res4.loanPx).to.equal(ONE.mul(9));
+      expect(res4.initLiquidity).to.equal(liquidity.div(2));
       expect(res4.loanLiquidity).to.equal(liquidity.div(2));
       expect(res4.loanLpTokens).to.equal(lpTokens.div(2));
       expect(res4.borrowedInvariant).to.equal(liquidity.div(2));
@@ -1734,6 +1743,7 @@ describe("LongStrategy", function () {
       await (await strategy.testPayLoan(tokenId, liquidity.div(2))).wait();
       const res5 = await strategy.getLoanChangeData(tokenId);
       expect(res5.loanPx).to.equal(0);
+      expect(res5.initLiquidity).to.equal(0);
       expect(res5.loanLiquidity).to.equal(0);
       expect(res5.loanLpTokens).to.equal(0);
       expect(res5.borrowedInvariant).to.equal(0);
@@ -1774,6 +1784,7 @@ describe("LongStrategy", function () {
       await (await strategy.testOpenLoan(tokenId, lpTokens)).wait();
       const res2 = await strategy.getLoanChangeData(tokenId);
       expect(res2.loanPx).to.equal(ONE.mul(11));
+      expect(res2.initLiquidity).to.equal(liquidity);
       expect(res2.loanLiquidity).to.equal(liquidity);
       expect(res2.loanLpTokens).to.equal(lpTokens);
       expect(res2.borrowedInvariant).to.equal(liquidity);
@@ -1794,6 +1805,7 @@ describe("LongStrategy", function () {
       await (await strategy.testPayLoan(tokenId, liquidity.div(2))).wait();
       const res4 = await strategy.getLoanChangeData(tokenId);
       expect(res4.loanPx).to.equal(ONE.mul(11));
+      expect(res4.initLiquidity).to.equal(liquidity.div(2));
       expect(res4.loanLiquidity).to.equal(liquidity.div(2));
       expect(res4.loanLpTokens).to.equal(lpTokens.div(2));
       expect(res4.borrowedInvariant).to.equal(liquidity.div(2));
@@ -1994,6 +2006,7 @@ describe("LongStrategy", function () {
       );
 
       const res2 = await strategy.getLoanChangeData(tokenId);
+      expect(res2.initLiquidity).to.equal(ONE.mul(2));
       expect(res2.loanLiquidity).to.equal(ONE.mul(2));
       expect(res2.loanLpTokens).to.equal(lpTokens);
       expect(res2.borrowedInvariant).to.equal(expectedLiquidity);


### PR DESCRIPTION
-exclude origination fees in initLiquidity calculation when opening a loan
-update unit tests

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205443170550898