### PR TITLE
initial mint correct decimals in FaucetERC20

### DIFF
--- a/contracts/test/FaucetERC20.sol
+++ b/contracts/test/FaucetERC20.sol
@@ -17,7 +17,7 @@ contract FaucetERC20 is ERC20 {
 
     constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {
         owner = msg.sender;
-        _mint(msg.sender, 1000000000 * (1e18));
+        _mint(msg.sender, 1000000000 * (10 ** decimals()));
         isFaucetOpen = true;
         tokenAmount = 10;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "0.5.33",
+  "version": "0.5.34",
   "description": "Core smart contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",


### PR DESCRIPTION
-use correct decimal expansion for tokens in initial mint of FaucetERC20 constructor
