### PR TITLE
fix/Flash Loan Fee Sync With Borrowed Invariant

### DIFF
--- a/contracts/strategies/liquidation/ExternalLiquidationStrategy.sol
+++ b/contracts/strategies/liquidation/ExternalLiquidationStrategy.sol
@@ -34,6 +34,9 @@ abstract contract ExternalLiquidationStrategy is IExternalLiquidationStrategy, B
         uint256 loanLiquidity = _liqLoan.loanLiquidity;
         if(liquiditySwapped > loanLiquidity) {
             uint256 swapFee = calcExternalSwapFee(liquiditySwapped, loanLiquidity) / 2;
+            uint256 borrowedInvariant = s.BORROWED_INVARIANT + swapFee;
+            s.LP_TOKEN_BORROWED_PLUS_INTEREST = convertInvariantToLP(borrowedInvariant, s.lastCFMMTotalSupply, s.lastCFMMInvariant);
+            s.BORROWED_INVARIANT = uint128(borrowedInvariant);
             loanLiquidity += swapFee;
             _loan.liquidity = uint128(loanLiquidity);
             _liqLoan.payableInternalLiquidity += swapFee;

--- a/contracts/strategies/rebalance/ExternalRebalanceStrategy.sol
+++ b/contracts/strategies/rebalance/ExternalRebalanceStrategy.sol
@@ -30,7 +30,11 @@ abstract contract ExternalRebalanceStrategy is IExternalRebalanceStrategy, BaseE
         _loan.tokensHeld = tokensHeld;
 
         if(liquiditySwapped > loanLiquidity) {
-            loanLiquidity = loanLiquidity + calcExternalSwapFee(liquiditySwapped, loanLiquidity);
+            uint256 fee = calcExternalSwapFee(liquiditySwapped, loanLiquidity);
+            uint256 borrowedInvariant = s.BORROWED_INVARIANT + fee;
+            s.LP_TOKEN_BORROWED_PLUS_INTEREST = convertInvariantToLP(borrowedInvariant, s.lastCFMMTotalSupply, s.lastCFMMInvariant);
+            s.BORROWED_INVARIANT = uint128(borrowedInvariant);
+            loanLiquidity = loanLiquidity + fee;
             _loan.liquidity = uint128(loanLiquidity);
         }
 

--- a/contracts/test/strategies/external/TestExternalBaseRebalanceStrategy.sol
+++ b/contracts/test/strategies/external/TestExternalBaseRebalanceStrategy.sol
@@ -77,6 +77,13 @@ abstract contract TestExternalBaseRebalanceStrategy is BaseExternalStrategy {
         lpInvariant = s.LP_INVARIANT;
     }
 
+    function getBorrowedBalances() external virtual view returns(uint256 borrowedInvariant,
+        uint256 lpTokensBorrowedPlusInterest, uint256 lpTokensBorrowed) {
+        borrowedInvariant = s.BORROWED_INVARIANT;
+        lpTokensBorrowedPlusInterest = s.LP_TOKEN_BORROWED_PLUS_INTEREST;
+        lpTokensBorrowed = s.LP_TOKEN_BORROWED;
+    }
+
     // create loan
     function createLoan(uint128 liquidity) external virtual returns(uint256 tokenId) {
         tokenId = s.createLoan(s.tokens.length, 0);

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,3 +6,6 @@ solc_version = '0.8.21'
 test = 'test'
 match_path = '*.t.sol'
 cache_path  = 'cache_forge'
+
+[fuzz]
+runs = 10000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Core smart contracts for the GammaSwap V1 protocol",
   "homepage": "https://gammaswap.com",
   "scripts": {

--- a/test/foundry/ExternalRebalanceStrategy.t.sol
+++ b/test/foundry/ExternalRebalanceStrategy.t.sol
@@ -90,6 +90,19 @@ contract ExternalRebalanceStrategyTest is Test {
     assertEq(postLpTokenBalance, lpTokenBalance);
   }
 
+  struct PoolData {
+    uint128[] tokenBalances;
+    uint256 lpTokenBalance;
+    uint256 swappedCollateralAsLPTokens;
+    uint256 swappedLiquidity;
+    uint128[] cfmmReserves;
+    uint256 lastCFMMTotalSupply;
+    uint256 lastCFMMInvariant;
+    uint256 borrowedInvariant;
+    uint256 lpTokensBorrowedPlusInterest;
+    uint256 lpTokensBorrowed;
+    uint256 prevLiquidity;
+  }
 
   function test_rebalance_externally2(uint256 amt0, uint256 amt1, uint256 lpAmt) public {
     assertEq(strategy.swapFee(), 10);
@@ -101,16 +114,34 @@ contract ExternalRebalanceStrategyTest is Test {
     // another loan
     _createLoan(amount0, amount1, liquidity);
 
-    (uint128[] memory tokenBalances,,,,uint256 lpTokenBalance,) = strategy.getPoolBalances();
-    assertEq(tokenBalances[0] - amount0, tokensHeld[0]);
-
     amt0 = bound(amt0, 0, tokensHeld[0]);
     amt1 = bound(amt1, 0, tokensHeld[1]);
-    lpAmt = bound(lpAmt, 0, lpTokenBalance);
+
+    PoolData memory data;
+    {
+      (data.tokenBalances, data.cfmmReserves, data.lastCFMMTotalSupply, data.lastCFMMInvariant, data.lpTokenBalance,)
+        = strategy.getPoolBalances();
+      assertEq(data.tokenBalances[0] - amount0, tokensHeld[0]);
+      assertEq(data.tokenBalances[1] - amount1, tokensHeld[1]);
+
+      lpAmt = bound(lpAmt, 0, data.lpTokenBalance);
+      // Collateral sent is measured as max of LP token equivalent if requested proportionally at current CFMM pool price
+      data.swappedCollateralAsLPTokens += tokensHeld[0] * (data.lastCFMMTotalSupply / 2) / data.cfmmReserves[0];
+      data.swappedCollateralAsLPTokens += tokensHeld[1] * (data.lastCFMMTotalSupply / 2) / data.cfmmReserves[1];
+      data.swappedCollateralAsLPTokens += lpAmt;
+      data.swappedLiquidity = data.swappedCollateralAsLPTokens * data.lastCFMMInvariant / data.lastCFMMTotalSupply;
+    }
+
+    data.prevLiquidity = liquidity;
+    if(data.swappedLiquidity > liquidity) {
+      liquidity = liquidity + uint128((data.swappedLiquidity - uint256(liquidity)) * uint256(strategy.swapFee()) / 10000);
+    }
 
     TestExternalCallee2.SwapData memory swapData = TestExternalCallee2.SwapData({ strategy: address(strategy),
     cfmm: address(cfmm), token0: address(tokenA), token1: address(tokenB), amount0: amt0, amount1: amt1,
     lpTokens: lpAmt});
+
+    (data.borrowedInvariant, data.lpTokensBorrowedPlusInterest, data.lpTokensBorrowed) = strategy.getBorrowedBalances();
 
     if(GSMath.sqrt(uint256(amt0) * amt1) * strategy.ltvThreshold() / 10000 >= liquidity) {
       strategy._rebalanceExternally(
@@ -120,13 +151,22 @@ contract ExternalRebalanceStrategyTest is Test {
         address(callee),
         abi.encode(swapData)
       );
+      if(data.swappedLiquidity > data.prevLiquidity) {
+        (,,,,,uint256 newLiquidity,,) = strategy.getLoan(tokenId);
+        assertGt(newLiquidity, data.prevLiquidity);
+        (newLiquidity,,) = strategy.getBorrowedBalances();
+        assertGt(newLiquidity, data.borrowedInvariant);
+      } else {
+        (uint256 newLiquidity,,) = strategy.getBorrowedBalances();
+        assertEq(newLiquidity, data.borrowedInvariant);
+      }
 
       (uint128[] memory postTokenBalances,,,,
       uint256 postLpTokenBalance,) = strategy.getPoolBalances();
 
-      assertEq(postTokenBalances[0], tokenBalances[0] - (tokensHeld[0] - amt0));
-      assertEq(postTokenBalances[1], tokenBalances[1] - (tokensHeld[1] - amt1));
-      assertEq(postLpTokenBalance, lpTokenBalance);
+      assertEq(postTokenBalances[0], data.tokenBalances[0] - (tokensHeld[0] - amt0));
+      assertEq(postTokenBalances[1], data.tokenBalances[1] - (tokensHeld[1] - amt1));
+      assertEq(postLpTokenBalance, data.lpTokenBalance);
     } else {
       vm.expectRevert(bytes4(keccak256("Margin()")));
       strategy._rebalanceExternally(
@@ -140,9 +180,9 @@ contract ExternalRebalanceStrategyTest is Test {
       (uint128[] memory postTokenBalances,,,,
       uint256 postLpTokenBalance,) = strategy.getPoolBalances();
 
-      assertEq(postTokenBalances[0], tokenBalances[0]);
-      assertEq(postTokenBalances[1], tokenBalances[1]);
-      assertEq(postLpTokenBalance, lpTokenBalance);
+      assertEq(postTokenBalances[0], data.tokenBalances[0]);
+      assertEq(postTokenBalances[1], data.tokenBalances[1]);
+      assertEq(postLpTokenBalance, data.lpTokenBalance);
     }
 
   }


### PR DESCRIPTION
-add flash loan fee to borrowed invariant in external rebalance and external liquidation strategies
-update test_rebalance_externally2 to take into account flash loan fee and check that borrowed invariant increased due to rebalancing externally
-increase foundry runs to 10,000 runs

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206135658502067