### PR TITLE
Make minBorrow an editable storage parameter

### DIFF
--- a/contracts/GammaPoolFactory.sol
+++ b/contracts/GammaPoolFactory.sol
@@ -92,7 +92,8 @@ contract GammaPoolFactory is AbstractGammaPoolFactory, AbstractRateParamsStore, 
         pool = cloneDeterministic(implementation, key);
 
         uint8[] memory _decimals = getDecimals(_tokensOrdered);
-        IGammaPool(pool).initialize(_cfmm, _tokensOrdered, _decimals, _data); // initialize GammaPool's state variables
+        uint72 _minBorrow = uint72(10**((_decimals[0] + _decimals[1]) / 2));
+        IGammaPool(pool).initialize(_cfmm, _tokensOrdered, _decimals, _minBorrow, _data); // initialize GammaPool's state variables
 
         getPool[key] = pool; // map unique key to new instance of GammaPool
         getKey[pool] = key; // map unique key to new instance of GammaPool

--- a/contracts/base/AbstractGammaPoolFactory.sol
+++ b/contracts/base/AbstractGammaPoolFactory.sol
@@ -73,10 +73,10 @@ abstract contract AbstractGammaPoolFactory is IGammaPoolFactory, TwoStepOwnable 
     }
 
     /// @dev See {IGammaPoolFactory-setPoolParams}
-    function setPoolParams(address _pool, uint16 _origFee, uint8 _extSwapFee, uint8 _emaMultiplier, uint8 _minUtilRate1, uint8 _minUtilRate2, uint16 _feeDivisor, uint8 _liquidationFee, uint8 _ltvThreshold) external virtual override {
+    function setPoolParams(address _pool, uint16 _origFee, uint8 _extSwapFee, uint8 _emaMultiplier, uint8 _minUtilRate1, uint8 _minUtilRate2, uint16 _feeDivisor, uint8 _liquidationFee, uint8 _ltvThreshold, uint72 _minBorrow) external virtual override {
         isForbidden(feeToSetter); // only feeToSetter can update origination fee parameters
-        IGammaPool(_pool).setPoolParams(_origFee, _extSwapFee, _emaMultiplier, _minUtilRate1, _minUtilRate2, _feeDivisor, _liquidationFee, _ltvThreshold);
-        emit PoolParamsUpdate(_pool, _origFee, _extSwapFee, _emaMultiplier, _minUtilRate1, _minUtilRate2, _feeDivisor, _liquidationFee, _ltvThreshold);
+        IGammaPool(_pool).setPoolParams(_origFee, _extSwapFee, _emaMultiplier, _minUtilRate1, _minUtilRate2, _feeDivisor, _liquidationFee, _ltvThreshold, _minBorrow);
+        emit PoolParamsUpdate(_pool, _origFee, _extSwapFee, _emaMultiplier, _minUtilRate1, _minUtilRate2, _feeDivisor, _liquidationFee, _ltvThreshold, _minBorrow);
     }
 
     /// @dev See {IGammaPoolFactory-setFee}

--- a/contracts/interfaces/IGammaPool.sol
+++ b/contracts/interfaces/IGammaPool.sol
@@ -231,6 +231,8 @@ interface IGammaPool is IGammaPoolEvents, IGammaPoolERC20Events, IRateModel {
         uint8 minUtilRate2;
         /// @dev Dynamic origination fee divisor
         uint16 feeDivisor;
+        /// @dev Minimum liquidity amount that can be borrowed
+        uint72 minBorrow;
     }
 
     /// @dev Function to initialize state variables GammaPool, called usually from GammaPoolFactory contract right after GammaPool instantiation
@@ -238,7 +240,8 @@ interface IGammaPool is IGammaPoolEvents, IGammaPoolERC20Events, IRateModel {
     /// @param _tokens - ERC20 tokens of CFMM
     /// @param _decimals - decimals of CFMM tokens, indices must match _tokens[] array
     /// @param _data - custom struct containing additional information used to verify the `_cfmm`
-    function initialize(address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals, bytes calldata _data) external;
+    /// @param _minBorrow - minimum amount of liquidity that can be borrowed or left unpaid in a loan
+    function initialize(address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals, uint72 _minBorrow, bytes calldata _data) external;
 
     /// @dev Set parameters to calculate origination fee, liquidation fee, and ltv threshold
     /// @param origFee - loan opening origination fee in basis points
@@ -249,7 +252,8 @@ interface IGammaPool is IGammaPoolEvents, IGammaPoolERC20Events, IRateModel {
     /// @param feeDivisor - fee divisor for calculating origination fee, based on 2^(maxUtilRate - minUtilRate1)
     /// @param liquidationFee - liquidation fee to charge during liquidations in basis points (1 - 255 => 0.01% to 2.55%)
     /// @param ltvThreshold - ltv threshold (1 - 255 => 0.1% to 25.5%)
-    function setPoolParams(uint16 origFee, uint8 extSwapFee, uint8 emaMultiplier, uint8 minUtilRate1, uint8 minUtilRate2, uint16 feeDivisor, uint8 liquidationFee, uint8 ltvThreshold) external;
+    /// @param minBorrow - minimum liquidity amount that can be borrowed or left unpaid in a loan
+    function setPoolParams(uint16 origFee, uint8 extSwapFee, uint8 emaMultiplier, uint8 minUtilRate1, uint8 minUtilRate2, uint16 feeDivisor, uint8 liquidationFee, uint8 ltvThreshold, uint72 minBorrow) external;
 
     /// @dev cfmm - address of CFMM this GammaPool is for
     function cfmm() external view returns(address);

--- a/contracts/interfaces/IGammaPoolFactory.sol
+++ b/contracts/interfaces/IGammaPoolFactory.sol
@@ -32,7 +32,8 @@ interface IGammaPoolFactory {
     /// @param feeDivisor - fee divisor for calculating origination fee, based on 2^(maxUtilRate - minUtilRate1)
     /// @param liquidationFee - liquidation fee to charge during liquidations in basis points (1 - 255 => 0.01% to 2.55%)
     /// @param ltvThreshold - ltv threshold (1 - 255 => 0.1% to 25.5%)
-    event PoolParamsUpdate(address indexed pool, uint16 origFee, uint8 extSwapFee, uint8 emaMultiplier, uint8 minUtilRate1, uint8 minUtilRate2, uint16 feeDivisor, uint8 liquidationFee, uint8 ltvThreshold);
+    /// @param minBorrow - minimum liquidity amount that can be borrowed or left unpaid in a loan
+    event PoolParamsUpdate(address indexed pool, uint16 origFee, uint8 extSwapFee, uint8 emaMultiplier, uint8 minUtilRate1, uint8 minUtilRate2, uint16 feeDivisor, uint8 liquidationFee, uint8 ltvThreshold, uint72 minBorrow);
 
     /// @dev Check if protocol is restricted. Which means only owner of GammaPoolFactory is allowed to instantiate GammaPools using this protocol
     /// @param _protocolId - id identifier of GammaPool protocol (can be thought of as version) that is being checked
@@ -106,7 +107,8 @@ interface IGammaPoolFactory {
     /// @param _feeDivisor - fee divisor for calculating origination fee, based on 2^(maxUtilRate - minUtilRate1)
     /// @param _liquidationFee - liquidation fee to charge during liquidations in basis points (1 - 255 => 0.01% to 2.55%)
     /// @param _ltvThreshold - ltv threshold (1 - 255 => 0.1% to 25.5%)
-    function setPoolParams(address _pool, uint16 _origFee, uint8 _extSwapFee, uint8 _emaMultiplier, uint8 _minUtilRate1, uint8 _minUtilRate2, uint16 _feeDivisor, uint8 _liquidationFee, uint8 _ltvThreshold) external;
+    /// @param _minBorrow - minimum liquidity amount that can be borrowed or left unpaid in a loan
+    function setPoolParams(address _pool, uint16 _origFee, uint8 _extSwapFee, uint8 _emaMultiplier, uint8 _minUtilRate1, uint8 _minUtilRate2, uint16 _feeDivisor, uint8 _liquidationFee, uint8 _ltvThreshold, uint72 _minBorrow) external;
 
     /// @dev Pause a GammaPool's function identified by a `_functionId`
     /// @param _pool - address of GammaPool whose functions we will pause

--- a/contracts/libraries/LibStorage.sol
+++ b/contracts/libraries/LibStorage.sol
@@ -116,6 +116,9 @@ library LibStorage {
         /// @dev Mapping of all loans issued by the GammaPool, the key is the tokenId (unique identifier) of the loan
         mapping(uint256 => Loan) loans;
 
+        /// @dev Minimum liquidity that can be borrowed or remain for a loan
+        uint72 minBorrow;
+
         // tokens and balances
         /// @dev ERC20 tokens of CFMM
         address[] tokens;
@@ -144,7 +147,8 @@ library LibStorage {
     /// @param _protocolId - protocol id of the implementation contract for this GammaPool
     /// @param _tokens - tokens of CFMM this GammaPool is for
     /// @param _decimals -decimals of the tokens of the CFMM the GammaPool is for, indices must match tokens array
-    function initialize(Storage storage self, address _factory, address _cfmm, uint16 _protocolId, address[] calldata _tokens, uint8[] calldata _decimals) internal {
+    /// @param _minBorrow - minimum amount of liquidity that can be borrowed or left unpaid in a loan
+    function initialize(Storage storage self, address _factory, address _cfmm, uint16 _protocolId, address[] calldata _tokens, uint8[] calldata _decimals, uint72 _minBorrow) internal {
         if(self.factory != address(0)) revert Initialized();// cannot initialize twice
 
         self.factory = _factory;
@@ -152,6 +156,7 @@ library LibStorage {
         self.cfmm = _cfmm;
         self.tokens = _tokens;
         self.decimals = _decimals;
+        self.minBorrow =_minBorrow;
 
         self.lastCFMMFeeIndex = 1e18;
         self.accFeeIndex = 1e18; // initialized as 1 with 18 decimal places

--- a/contracts/strategies/base/BaseLiquidationStrategy.sol
+++ b/contracts/strategies/base/BaseLiquidationStrategy.sol
@@ -132,7 +132,7 @@ abstract contract BaseLiquidationStrategy is ILiquidationStrategy, BaseRepayStra
     function calcExcessLiquidity(uint256 liquidityDeposit, uint256 loanLiquidity, bool fullDeposit) internal virtual returns(uint256 excessLiquidity){
         if(fullDeposit && liquidityDeposit < loanLiquidity) {
             revert InsufficientDeposit();
-        } else if(liquidityDeposit > (loanLiquidity + minBorrow())) {
+        } else if(liquidityDeposit > (loanLiquidity + minPay())) {
             unchecked {
                 excessLiquidity = liquidityDeposit - loanLiquidity;
             }

--- a/contracts/strategies/base/BaseLongStrategy.sol
+++ b/contracts/strategies/base/BaseLongStrategy.sol
@@ -18,7 +18,12 @@ abstract contract BaseLongStrategy is ILongStrategy, BaseStrategy {
     error InvalidAmountsLength();
 
     /// @dev Minimum number of liquidity borrowed to avoid rounding issues. Assumes invariant >= CFMM LP Token. Default should be 1e3
-    function minBorrow() internal view virtual returns(uint256);
+    function minBorrow() internal view virtual returns(uint256) {
+        return s.minBorrow;
+    }
+
+    /// @dev Minimum amount of liquidity to pay to avoid rounding issues. Assumes invariant >= CFMM LP Token. Default should be 1e3
+    function minPay() internal view virtual returns(uint256);
 
     /// @dev Perform necessary transaction before repaying liquidity debt
     /// @param _loan - liquidity loan that will be repaid

--- a/contracts/strategies/lending/RepayStrategy.sol
+++ b/contracts/strategies/lending/RepayStrategy.sol
@@ -89,7 +89,7 @@ abstract contract RepayStrategy is IRepayStrategy, BaseRepayStrategy {
         {
             // Cap liquidity repayment at total liquidity debt
             uint256 liquidityToCalculate;
-            (liquidityPaid, liquidityToCalculate) = payLiquidity >= loanLiquidity ? (loanLiquidity, loanLiquidity + minBorrow() * 10) : (payLiquidity, payLiquidity);
+            (liquidityPaid, liquidityToCalculate) = payLiquidity >= loanLiquidity ? (loanLiquidity, loanLiquidity + minPay()) : (payLiquidity, payLiquidity);
 
             int256[] memory deltas = _calcDeltasToCloseSetRatio(tokensHeld, s.CFMM_RESERVES, liquidityToCalculate,
                 isRatioValid(ratio) ? ratio : GammaSwapLibrary.convertUint128ToRatio(tokensHeld));
@@ -139,7 +139,7 @@ abstract contract RepayStrategy is IRepayStrategy, BaseRepayStrategy {
         {
             // Cap liquidity repayment at total liquidity debt
             uint256 liquidityToCalculate;
-            (liquidityPaid, liquidityToCalculate) = payLiquidity >= loanLiquidity ? (loanLiquidity, loanLiquidity + minBorrow() * 10) : (payLiquidity, payLiquidity);
+            (liquidityPaid, liquidityToCalculate) = payLiquidity >= loanLiquidity ? (loanLiquidity, loanLiquidity + minPay()) : (payLiquidity, payLiquidity);
 
             if(collateralId > 0) {
                 collateral = proRataCollateral(collateral, liquidityToCalculate, loanLiquidity, 1);

--- a/contracts/strategies/liquidation/SingleLiquidationStrategy.sol
+++ b/contracts/strategies/liquidation/SingleLiquidationStrategy.sol
@@ -32,7 +32,7 @@ abstract contract SingleLiquidationStrategy is ISingleLiquidationStrategy, BaseL
         if(_liqLoan.payableInternalLiquidityPlusFee > 0) {
             uint256 lpDeposit = repayTokens(_loan, calcTokensToRepay(s.CFMM_RESERVES, _liqLoan.payableInternalLiquidityPlusFee, tokensHeld));
             refund = lpDeposit * _liqLoan.internalFee / _liqLoan.payableInternalLiquidityPlusFee;
-            if(refund <= minBorrow()) {
+            if(refund <= minPay()) {
                 refund = 0;
             } else {
                 GammaSwapLibrary.safeTransfer(s.cfmm, msg.sender, refund);

--- a/contracts/test/TestGammaPoolFactory.sol
+++ b/contracts/test/TestGammaPoolFactory.sol
@@ -27,7 +27,7 @@ contract TestGammaPoolFactory is AbstractGammaPoolFactory {
         pool = cloneDeterministic(protocol, key);
         decimals[0] = 18;
         decimals[1] = 18;
-        IGammaPool(pool).initialize(cfmm, tokens, decimals, _data);
+        IGammaPool(pool).initialize(cfmm, tokens, decimals, uint72(1e3), _data);
 
         getPool[key] = pool;
         getKey[pool] = key;

--- a/contracts/test/strategies/base/TestBaseShortStrategy.sol
+++ b/contracts/test/strategies/base/TestBaseShortStrategy.sol
@@ -14,7 +14,7 @@ abstract contract TestBaseShortStrategy is ShortStrategy {
     }
 
     function initialize(address cfmm, address[] calldata tokens, uint8[] calldata decimals) external virtual {
-        s.initialize(msg.sender, cfmm, 1, tokens, decimals);
+        s.initialize(msg.sender, cfmm, 1, tokens, decimals, 1e3);
     }
 
     function maxTotalApy() internal virtual override view returns(uint256) {

--- a/contracts/test/strategies/base/TestBaseStrategy.sol
+++ b/contracts/test/strategies/base/TestBaseStrategy.sol
@@ -24,7 +24,7 @@ contract TestBaseStrategy is BaseStrategy {
     }
 
     function initialize(address cfmm, address[] calldata tokens, uint8[] calldata decimals) external virtual {
-        s.initialize(_factory, cfmm, _protocolId, tokens, decimals);
+        s.initialize(_factory, cfmm, _protocolId, tokens, decimals, 1e3);
     }
 
     function maxTotalApy() internal virtual override view returns(uint256) {

--- a/contracts/test/strategies/base/TestBorrowStrategy.sol
+++ b/contracts/test/strategies/base/TestBorrowStrategy.sol
@@ -15,7 +15,7 @@ contract TestBorrowStrategy is BorrowStrategy {
     uint80 public borrowRate = 1e18;
     uint16 public origFee = 0;
     uint16 public protocolId;
-    uint256 private _minBorrow = 1e3;
+    uint256 private _minPay = 1e3;
     uint256 private mCurrPrice = 1e18;
 
     constructor() {
@@ -23,22 +23,22 @@ contract TestBorrowStrategy is BorrowStrategy {
 
     function initialize(address _factory, address _cfmm, uint16 _protocolId, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {
         protocolId = _protocolId;
-        s.initialize(_factory, _cfmm, _protocolId, _tokens, _decimals);
+        s.initialize(_factory, _cfmm, _protocolId, _tokens, _decimals, 1e3);
     }
 
     function setOrigFeeParams(uint8 baseOrigFee) external virtual {
         s.origFee = baseOrigFee;
     }
 
-    function setMinBorrow(uint256 _newMinBorrow) external virtual {
-        _minBorrow = _newMinBorrow;
+    function setMinPay(uint256 _newMinPay) external virtual {
+        _minPay = _newMinPay;
     }
 
     function syncCFMM(address cfmm) internal override virtual {
     }
 
-    function minBorrow() internal virtual override view returns(uint256) {
-        return _minBorrow;
+    function minPay() internal virtual override view returns(uint256) {
+        return _minPay;
     }
 
     function maxTotalApy() internal virtual override view returns(uint256) {

--- a/contracts/test/strategies/base/TestLiquidationStrategy.sol
+++ b/contracts/test/strategies/base/TestLiquidationStrategy.sol
@@ -30,10 +30,10 @@ contract TestLiquidationStrategy is SingleLiquidationStrategy, BatchLiquidationS
     }
 
     function initialize(address _factory, address cfmm, address[] calldata tokens, uint8[] calldata decimals) external virtual {
-        s.initialize(_factory, cfmm, 1, tokens, decimals);
+        s.initialize(_factory, cfmm, 1, tokens, decimals, 1e3);
     }
 
-    function minBorrow() internal virtual override view returns(uint256) {
+    function minPay() internal virtual override view returns(uint256) {
         return 1e3;
     }
 

--- a/contracts/test/strategies/base/TestLongStrategy.sol
+++ b/contracts/test/strategies/base/TestLongStrategy.sol
@@ -15,7 +15,7 @@ contract TestLongStrategy is RepayStrategy, BorrowStrategy {
     uint80 public borrowRate = 1e18;
     uint16 public origFee = 0;
     uint16 public protocolId;
-    uint256 private _minBorrow = 1e3;
+    uint256 private _minPay = 1e3;
     uint256 private mCurrPrice = 1e18;
 
     constructor() {
@@ -23,15 +23,15 @@ contract TestLongStrategy is RepayStrategy, BorrowStrategy {
 
     function initialize(address _factory, address _cfmm, uint16 _protocolId, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {
         protocolId = _protocolId;
-        s.initialize(_factory, _cfmm, _protocolId, _tokens, _decimals);
+        s.initialize(_factory, _cfmm, _protocolId, _tokens, _decimals, 1e3);
     }
 
-    function setMinBorrow(uint256 _newMinBorrow) external virtual {
-        _minBorrow = _newMinBorrow;
+    function setMinPay(uint256 _newMinPay) external virtual {
+        _minPay = _newMinPay;
     }
 
-    function minBorrow() internal virtual override view returns(uint256) {
-        return _minBorrow;
+    function minPay() internal virtual override view returns(uint256) {
+        return _minPay;
     }
 
     function maxTotalApy() internal virtual override view returns(uint256) {

--- a/contracts/test/strategies/base/TestRebalanceStrategy.sol
+++ b/contracts/test/strategies/base/TestRebalanceStrategy.sol
@@ -14,7 +14,7 @@ contract TestRebalanceStrategy is BorrowStrategy, RebalanceStrategy {
     uint80 public borrowRate = 1e18;
     uint16 public origFee = 0;
     uint16 public protocolId;
-    uint256 private _minBorrow = 1e3;
+    uint256 private _minPay = 1e3;
     uint256 private mCurrPrice = 1e18;
 
     constructor() {
@@ -22,15 +22,15 @@ contract TestRebalanceStrategy is BorrowStrategy, RebalanceStrategy {
 
     function initialize(address _factory, address _cfmm, uint16 _protocolId, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {
         protocolId = _protocolId;
-        s.initialize(_factory, _cfmm, _protocolId, _tokens, _decimals);
+        s.initialize(_factory, _cfmm, _protocolId, _tokens, _decimals, 1e3);
     }
 
-    function setMinBorrow(uint256 _newMinBorrow) external virtual {
-        _minBorrow = _newMinBorrow;
+    function setMinPay(uint256 _newMinPay) external virtual {
+        _minPay = _newMinPay;
     }
 
-    function minBorrow() internal virtual override view returns(uint256) {
-        return _minBorrow;
+    function minPay() internal virtual override view returns(uint256) {
+        return _minPay;
     }
 
     function maxTotalApy() internal virtual override view returns(uint256) {

--- a/contracts/test/strategies/base/TestRepayStrategy.sol
+++ b/contracts/test/strategies/base/TestRepayStrategy.sol
@@ -14,7 +14,7 @@ contract TestRepayStrategy is RepayStrategy, BorrowStrategy {
     uint80 public borrowRate = 1e18;
     uint16 public origFee = 0;
     uint16 public protocolId;
-    uint256 private _minBorrow = 1e3;
+    uint256 private _minPay = 1e3;
     uint256 private mCurrPrice = 1e18;
 
     constructor() {
@@ -22,15 +22,15 @@ contract TestRepayStrategy is RepayStrategy, BorrowStrategy {
 
     function initialize(address _factory, address _cfmm, uint16 _protocolId, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {
         protocolId = _protocolId;
-        s.initialize(_factory, _cfmm, _protocolId, _tokens, _decimals);
+        s.initialize(_factory, _cfmm, _protocolId, _tokens, _decimals, 1e3);
     }
 
-    function setMinBorrow(uint256 _newMinBorrow) external virtual {
-        _minBorrow = _newMinBorrow;
+    function setMinPay(uint256 _newMinPay) external virtual {
+        _minPay = _newMinPay;
     }
 
-    function minBorrow() internal virtual override view returns(uint256) {
-        return _minBorrow;
+    function minPay() internal virtual override view returns(uint256) {
+        return _minPay;
     }
 
     function maxTotalApy() internal virtual override view returns(uint256) {

--- a/contracts/test/strategies/external/TestExternalBaseRebalanceStrategy.sol
+++ b/contracts/test/strategies/external/TestExternalBaseRebalanceStrategy.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.4;
 
 import "../../../strategies/base/BaseExternalStrategy.sol";
 import "../../TestCFMM.sol";
+import "../../../strategies/base/BaseBorrowStrategy.sol";
 
 abstract contract TestExternalBaseRebalanceStrategy is BaseExternalStrategy {
 
@@ -20,7 +21,7 @@ abstract contract TestExternalBaseRebalanceStrategy is BaseExternalStrategy {
 
     function initialize(address factory, address _cfmm, uint16 _protocolId, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {
         protocolId = _protocolId;
-        s.initialize(factory, _cfmm, _protocolId, _tokens, _decimals);
+        s.initialize(factory, _cfmm, _protocolId, _tokens, _decimals, 1e3);
     }
 
     function maxTotalApy() internal virtual override view returns(uint256) {
@@ -35,7 +36,7 @@ abstract contract TestExternalBaseRebalanceStrategy is BaseExternalStrategy {
         return 8000;
     }
 
-    function minBorrow() internal view virtual override returns(uint256) {
+    function minPay() internal view virtual override returns(uint256) {
         return 1e3;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Core smart contracts for the GammaSwap V1 protocol",
   "homepage": "https://gammaswap.com",
   "scripts": {

--- a/test/GammaPoolFactory.test.ts
+++ b/test/GammaPoolFactory.test.ts
@@ -656,7 +656,7 @@ describe("GammaPoolFactory", function () {
       expect(await factory.allPoolsLength()).to.equal(1);
 
       await expect(
-        factory.connect(addr1).setPoolParams(pool, 1, 2, 3, 4, 5, 6, 7, 8)
+        factory.connect(addr1).setPoolParams(pool, 1, 2, 3, 4, 5, 6, 7, 8, 9)
       ).to.be.revertedWithCustomError(factory, "Forbidden");
     });
 
@@ -689,25 +689,41 @@ describe("GammaPoolFactory", function () {
       expect(pool).to.equal(expectedPoolAddress);
       expect(await factory.allPoolsLength()).to.equal(1);
 
-      await expect(factory.setPoolParams(pool, 1, 2, 3, 101, 60, 0, 11, 1))
+      await expect(
+        factory.setPoolParams(pool, 1, 2, 3, 101, 60, 0, 11, 1, 1000)
+      )
         .to.be.revertedWithCustomError(poolContract, "InvalidPoolParam")
         .withArgs(5);
 
-      await expect(factory.setPoolParams(pool, 1, 2, 3, 95, 60, 0, 11, 1))
+      await expect(factory.setPoolParams(pool, 1, 2, 3, 95, 60, 0, 11, 1, 1000))
         .to.be.revertedWithCustomError(poolContract, "InvalidPoolParam")
         .withArgs(5);
 
-      await expect(factory.setPoolParams(pool, 1, 2, 3, 94, 60, 0, 11, 1))
+      await expect(factory.setPoolParams(pool, 1, 2, 3, 94, 60, 0, 11, 1, 1000))
         .to.be.revertedWithCustomError(poolContract, "InvalidPoolParam")
         .withArgs(5);
 
-      await expect(factory.setPoolParams(pool, 1, 2, 3, 78, 60, 1, 11, 1))
+      await expect(factory.setPoolParams(pool, 1, 2, 3, 78, 60, 1, 11, 1, 1000))
         .to.be.revertedWithCustomError(poolContract, "InvalidPoolParam")
         .withArgs(6);
 
-      await expect(factory.setPoolParams(pool, 1, 2, 3, 77, 60, 100, 51, 5))
+      await expect(
+        factory.setPoolParams(pool, 1, 2, 3, 77, 60, 100, 51, 5, 1000)
+      )
         .to.be.revertedWithCustomError(poolContract, "InvalidPoolParam")
         .withArgs(6);
+
+      await expect(
+        factory.setPoolParams(pool, 1, 2, 3, 77, 60, 100, 51, 5, 1000)
+      )
+        .to.be.revertedWithCustomError(poolContract, "InvalidPoolParam")
+        .withArgs(6);
+
+      await expect(
+        factory.setPoolParams(pool, 1, 2, 3, 77, 60, 100, 50, 5, 999)
+      )
+        .to.be.revertedWithCustomError(poolContract, "InvalidPoolParam")
+        .withArgs(8);
     });
 
     it("Set Origination Fee", async function () {
@@ -746,7 +762,7 @@ describe("GammaPoolFactory", function () {
       expect(resp.feeDivisor).to.equal(16384);
 
       const tx = await (
-        await factory.setPoolParams(pool, 1, 2, 20, 84, 60, 1, 50, 10)
+        await factory.setPoolParams(pool, 1, 2, 20, 84, 60, 1, 50, 10, 1000)
       ).wait();
 
       const event = tx.events[tx.events.length - 1];
@@ -759,6 +775,7 @@ describe("GammaPoolFactory", function () {
       expect(event.args.feeDivisor).to.equal(1);
       expect(event.args.liquidationFee).to.equal(50);
       expect(event.args.ltvThreshold).to.equal(10);
+      expect(event.args.minBorrow).to.equal(1000);
 
       const resp1 = await gammaPool.getPoolData();
       expect(resp1.origFee).to.equal(1);
@@ -769,9 +786,10 @@ describe("GammaPoolFactory", function () {
       expect(resp1.feeDivisor).to.equal(1);
       expect(resp1.liquidationFee).to.equal(50);
       expect(resp1.ltvThreshold).to.equal(10);
+      expect(resp1.minBorrow).to.equal(1000);
 
       const tx1 = await (
-        await factory.setPoolParams(pool, 1, 2, 20, 84, 64, 65535, 50, 5)
+        await factory.setPoolParams(pool, 1, 2, 20, 84, 64, 65535, 50, 5, 2000)
       ).wait();
 
       const event1 = tx1.events[tx.events.length - 1];
@@ -784,6 +802,7 @@ describe("GammaPoolFactory", function () {
       expect(event1.args.feeDivisor).to.equal(65535);
       expect(event1.args.liquidationFee).to.equal(50);
       expect(event1.args.ltvThreshold).to.equal(5);
+      expect(event1.args.minBorrow).to.equal(2000);
 
       const resp2 = await gammaPool.getPoolData();
       expect(resp2.origFee).to.equal(1);
@@ -794,6 +813,7 @@ describe("GammaPoolFactory", function () {
       expect(resp2.feeDivisor).to.equal(65535);
       expect(resp2.liquidationFee).to.equal(50);
       expect(resp2.ltvThreshold).to.equal(5);
+      expect(resp2.minBorrow).to.equal(2000);
     });
   });
 

--- a/test/strategies/LongStrategy.test.ts
+++ b/test/strategies/LongStrategy.test.ts
@@ -2199,7 +2199,7 @@ describe("LongStrategy", function () {
       expect(res1b.liquidity).to.equal(loanLiquidity);
       expect(res1b.lpTokens).to.equal(loanLPTokens);
 
-      await (await strategy.setMinBorrow(0)).wait();
+      await (await strategy.setMinPay(0)).wait();
 
       const res = await (
         await strategy._repayLiquidity(
@@ -2279,7 +2279,7 @@ describe("LongStrategy", function () {
       await strategy.setCfmmReserves([lastCFMMInvariant, lastCFMMInvariant]);
 
       await (await cfmm.mint(startLpTokens, strategy.address)).wait();
-      await (await strategy.setMinBorrow(0)).wait();
+      await (await strategy.setMinPay(0)).wait();
 
       // const beneficiary = "0x000000000000000000000000000000000000dEaD";
       const res = await (
@@ -2715,7 +2715,7 @@ describe("LongStrategy", function () {
       expect(res1b.liquidity).to.equal(loanLiquidity);
       expect(res1b.lpTokens).to.equal(loanLPTokens);
 
-      await (await strategy.setMinBorrow(0)).wait();
+      await (await strategy.setMinPay(0)).wait();
 
       await (await cfmm.mint(loanLiquidity.div(2), strategy.address)).wait();
 
@@ -2823,7 +2823,7 @@ describe("LongStrategy", function () {
       expect(res1b.liquidity).to.equal(loanLiquidity);
       expect(res1b.lpTokens).to.equal(loanLPTokens);
 
-      await (await strategy.setMinBorrow(0)).wait();
+      await (await strategy.setMinPay(0)).wait();
 
       await (await cfmm.mint(loanLiquidity.div(2), strategy.address)).wait();
 


### PR DESCRIPTION
-make minBorrow() editable as a storage parameter
-use minPay() for minBorrow() in repayLiquidity and liquidation functions
-update unit tests