### PR TITLE
Feat: max leverage and spread come from RateModel

### DIFF
--- a/contracts/base/GammaPool.sol
+++ b/contracts/base/GammaPool.sol
@@ -291,15 +291,18 @@ abstract contract GammaPool is IGammaPool, GammaPoolERC4626 {
         if(start > end || _tokenIds.length == 0) {
             return _loans;
         }
-        uint256 lastIdx = _tokenIds.length - 1;
-        if(start <= lastIdx) {
-            uint256 _start = start;
-            uint256 _end = lastIdx < end ? lastIdx : end;
-            uint256 _size = _end - _start + 1;
-            _loans = new LoanData[](_size);
+        uint256 lastIdx;
+        unchecked {
+            lastIdx = _tokenIds.length - 1;
+        }
+        end = lastIdx < end ? lastIdx : end; // end = min(lastIdx,end) <= min(type(uint256).max-1,end)
+        if(start <= end) {
+            unchecked {
+                _loans = new LoanData[](1 + end - start);
+            }
             LoanData memory _loan;
             uint256 k = 0;
-            for(uint256 i = _start; i <= _end;) {
+            for(uint256 i = start; i <= end;) {
                 _loan = _getLoanData(_tokenIds[i]);
                 if(!active || _loan.initLiquidity > 0) {
                     _loans[k] = _loan;

--- a/contracts/base/GammaPoolERC4626.sol
+++ b/contracts/base/GammaPoolERC4626.sol
@@ -210,11 +210,12 @@ abstract contract GammaPoolERC4626 is GammaPoolERC20, DelegateCaller, Refunds, P
         uint256 latestCfmmInvariant = _getLatestCFMMInvariant();
         uint256 latestCfmmTotalSupply = _getLatestCFMMTotalSupply();
 
-        (uint256 borrowRate, uint256 utilizationRate) = AbstractRateModel(shortStrategy).calcBorrowRate(s.LP_INVARIANT,
+        (uint256 borrowRate, uint256 utilizationRate, uint256 maxCFMMFeeLeverage, uint256 spread) = AbstractRateModel(shortStrategy).calcBorrowRate(s.LP_INVARIANT,
             borrowedInvariant, factory, address(this));
 
         (uint256 lastFeeIndex, uint256 cfmmFeeIndex) = IShortStrategy(shortStrategy).getLastFees(borrowRate, borrowedInvariant,
-            latestCfmmInvariant, latestCfmmTotalSupply, s.lastCFMMInvariant, s.lastCFMMTotalSupply, s.LAST_BLOCK_NUMBER, s.lastCFMMFeeIndex);
+            latestCfmmInvariant, latestCfmmTotalSupply, s.lastCFMMInvariant, s.lastCFMMTotalSupply, s.LAST_BLOCK_NUMBER,
+            s.lastCFMMFeeIndex, maxCFMMFeeLeverage, spread);
 
         // Total amount of GS LP tokens issued
         assets = IShortStrategy(shortStrategy).totalAssets(borrowedInvariant, s.LP_TOKEN_BALANCE, latestCfmmInvariant, latestCfmmTotalSupply, lastFeeIndex);

--- a/contracts/interfaces/IGammaPool.sol
+++ b/contracts/interfaces/IGammaPool.sol
@@ -130,6 +130,10 @@ interface IGammaPool is IProtocol, IGammaPoolEvents, IGammaPoolERC20Events, IRat
         address shortStrategy;
         /// @dev Interest Rate Parameters Store contract
         address paramsStore;
+        /// @dev Max CFMM Yield Leverage
+        uint256 maxCFMMFeeLeverage;
+        /// @dev Spread to add to CFMM Fee Index
+        uint256 spread;
     }
 
     /// @dev Struct returned in getPoolData function. Contains all relevant global state variables
@@ -234,6 +238,10 @@ interface IGammaPool is IProtocol, IGammaPoolEvents, IGammaPoolERC20Events, IRat
         uint16 feeDivisor;
         /// @dev Minimum liquidity amount that can be borrowed
         uint72 minBorrow;
+        /// @dev Max CFMM Yield Leverage
+        uint256 maxCFMMFeeLeverage;
+        /// @dev Spread to add to CFMM Fee Index
+        uint256 spread;
     }
 
     /// @dev cfmm - address of CFMM this GammaPool is for

--- a/contracts/interfaces/strategies/base/IShortStrategy.sol
+++ b/contracts/interfaces/strategies/base/IShortStrategy.sol
@@ -70,11 +70,13 @@ interface IShortStrategy is IShortStrategyEvents {
     /// @param prevCFMMTotalSupply - total supply in CFMM in last update to GammaPool
     /// @param lastBlockNum - last block GammaPool was updated
     /// @param lastCFMMFeeIndex - last fees accrued by CFMM since last update
+    /// @param maxCFMMFeeLeverage - max leverage of CFMM yield
+    /// @param spread - spread to add to cfmmFeeIndex
     /// @return lastFeeIndex - last fees charged by GammaPool since last update
     /// @return updLastCFMMFeeIndex - updated fees accrued by CFMM till current block
     function getLastFees(uint256 borrowRate, uint256 borrowedInvariant, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply,
-        uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply, uint256 lastBlockNum, uint256 lastCFMMFeeIndex)
-        external view returns(uint256 lastFeeIndex, uint256 updLastCFMMFeeIndex);
+        uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply, uint256 lastBlockNum, uint256 lastCFMMFeeIndex,
+        uint256 maxCFMMFeeLeverage, uint256 spread) external view returns(uint256 lastFeeIndex, uint256 updLastCFMMFeeIndex);
 
     /// @dev Calculate balances updated by fees charged since last update
     /// @param lastFeeIndex - last fees charged by GammaPool since last update

--- a/contracts/libraries/LibStorage.sol
+++ b/contracts/libraries/LibStorage.sol
@@ -173,7 +173,7 @@ library LibStorage {
         self.emaMultiplier = 10; // ema smoothing factor is 10/1000 = 1%
         self.minUtilRate1 = 90; // min util rate 1 is 90%
         self.minUtilRate2 = 85; // min util rate 2 is 85%
-        self.feeDivisor = 2048; // max util rate is 99% => 2^(99 - minUtilRate1)
+        self.feeDivisor = 2048; // 25% orig fee at 99% util rate
 
         self.TOKEN_BALANCE = new uint128[](_tokens.length);
         self.CFMM_RESERVES = new uint128[](_tokens.length);

--- a/contracts/rates/AbstractRateModel.sol
+++ b/contracts/rates/AbstractRateModel.sol
@@ -29,7 +29,7 @@ abstract contract AbstractRateModel is IRateModel {
     /// @param pool - address of pool asking for rate calculation
     /// @return borrowRate - rate that will be charged to liquidity borrowers
     /// @return utilizationRate - utilization rate used to calculate the borrow rate
-    /// @return maxLeverage - maxLeverage number x 1000, e.g. 5000 = 5x
+    /// @return maxCFMMFeeLeverage - maxLeverage number x 1000, e.g. 5000 = 5x
     /// @return spread - additional fee to add to cfmmFeeIndex to create spread
     function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual view returns(uint256, uint256, uint256, uint256);
 

--- a/contracts/rates/AbstractRateModel.sol
+++ b/contracts/rates/AbstractRateModel.sol
@@ -31,6 +31,12 @@ abstract contract AbstractRateModel is IRateModel {
     /// @return utilizationRate - utilization rate used to calculate the borrow rate
     function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual view returns(uint256, uint256);
 
+    /// @notice Calculates cfmm yield max leverage multiplier
+    /// @param paramsStore - address of rate params store, to get overriding parameter values
+    /// @param pool - address of pool asking for rate calculation
+    /// @return maxLeverage - maxLeverage number x 1000, e.g. 5000 = 5x
+    function _calcMaxLeverage(address paramsStore, address pool) internal virtual view returns(uint256);
+
     /// @dev See {IRateModel-rateParamsStore}
     function rateParamsStore() public override virtual view returns(address) {
         return _rateParamsStore();

--- a/contracts/rates/AbstractRateModel.sol
+++ b/contracts/rates/AbstractRateModel.sol
@@ -29,13 +29,9 @@ abstract contract AbstractRateModel is IRateModel {
     /// @param pool - address of pool asking for rate calculation
     /// @return borrowRate - rate that will be charged to liquidity borrowers
     /// @return utilizationRate - utilization rate used to calculate the borrow rate
-    function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual view returns(uint256, uint256);
-
-    /// @notice Calculates cfmm yield max leverage multiplier
-    /// @param paramsStore - address of rate params store, to get overriding parameter values
-    /// @param pool - address of pool asking for rate calculation
     /// @return maxLeverage - maxLeverage number x 1000, e.g. 5000 = 5x
-    function _calcMaxLeverage(address paramsStore, address pool) internal virtual view returns(uint256);
+    /// @return spread - additional fee to add to cfmmFeeIndex to create spread
+    function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual view returns(uint256, uint256, uint256, uint256);
 
     /// @dev See {IRateModel-rateParamsStore}
     function rateParamsStore() public override virtual view returns(address) {

--- a/contracts/rates/AbstractRateModel.sol
+++ b/contracts/rates/AbstractRateModel.sol
@@ -29,7 +29,7 @@ abstract contract AbstractRateModel is IRateModel {
     /// @param pool - address of pool asking for rate calculation
     /// @return borrowRate - rate that will be charged to liquidity borrowers
     /// @return utilizationRate - utilization rate used to calculate the borrow rate
-    /// @return maxCFMMFeeLeverage - maxLeverage number x 1000, e.g. 5000 = 5x
+    /// @return maxCFMMFeeLeverage - maxLeverage number with 3 decimals. E.g. 5000 = 5
     /// @return spread - additional fee to add to cfmmFeeIndex to create spread
     function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual view returns(uint256, uint256, uint256, uint256);
 

--- a/contracts/rates/LinearKinkedRateModel.sol
+++ b/contracts/rates/LinearKinkedRateModel.sol
@@ -53,12 +53,13 @@ abstract contract LinearKinkedRateModel is AbstractRateModel, ILinearKinkedRateM
 
     /// @notice formula is as follows: max{ baseRate + (utilRate * slope1) / optimalRate, baseRate + slope1 + slope2 * (utilRate - optimalRate) / (1 - optimalUtilRate) }
     /// @dev See {AbstractRateModel-calcBorrowRate}.
-    function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual override view returns(uint256 borrowRate, uint256 utilizationRate) {
+    function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual override view returns(uint256 borrowRate, uint256 utilizationRate, uint256 maxLeverage, uint256 spread) {
         utilizationRate = calcUtilizationRate(lpInvariant, borrowedInvariant); // at most 1e18 < max(uint64)
-        if(utilizationRate == 0) { // if utilization rate is zero, the borrow rate is zero
-            return (0, 0);
-        }
         (uint64 _baseRate, uint64 _optimalUtilRate, uint64 _slope1, uint64 _slope2) = getRateModelParams(paramsStore, pool);
+        maxLeverage = _calcMaxLeverage(_optimalUtilRate);
+        if(utilizationRate == 0) { // if utilization rate is zero, the borrow rate is zero
+            return (0, 0, maxLeverage, 1e18);
+        }
         unchecked {
             if(utilizationRate <= _optimalUtilRate) { // if pool funds are underutilized use slope1
                 uint256 variableRate = (utilizationRate * _slope1) / _optimalUtilRate; // at most uint128
@@ -68,7 +69,18 @@ abstract contract LinearKinkedRateModel is AbstractRateModel, ILinearKinkedRateM
                 uint256 variableRate = (utilizationRateDiff * _slope2) / (1e18 - _optimalUtilRate); // at most uint128
                 borrowRate = _baseRate + _slope1 + variableRate;
             }
+            spread = _calcSpread(borrowRate);
         }
+    }
+
+    /// @dev return max leverage based on optimal utilization rate times 1000 (e.g. 1000 / (1 - optimalRate)
+    function _calcMaxLeverage(uint256 _optimalUtilRate) internal virtual view returns(uint256) {
+        return 1e21 / (1e18 - _optimalUtilRate);
+    }
+
+    /// @dev return spread to add to the CFMMFeeIndex as the borrow rate * 10
+    function _calcSpread(uint256 borrowRate) internal virtual view returns(uint256) {
+        return 1e18 + borrowRate * 10;
     }
 
     /// @dev Get interest rate model parameters
@@ -104,11 +116,5 @@ abstract contract LinearKinkedRateModel is AbstractRateModel, ILinearKinkedRateM
         if(!(_optimalUtilRate > 0 && _optimalUtilRate < 1e18)) revert OptimalUtilRate();
         if(_slope2 < _slope1) revert Slope2LtSlope1();
         return true;
-    }
-
-    /// @dev See {AbstractRateModel-_calcMaxLeverage}
-    function _calcMaxLeverage(address paramsStore, address pool) internal override virtual view returns(uint256) {
-        (,uint64 _optimalUtilRate,,) = getRateModelParams(paramsStore, pool);
-        return 1e21 / (1e18 - _optimalUtilRate);
     }
 }

--- a/contracts/rates/LinearKinkedRateModel.sol
+++ b/contracts/rates/LinearKinkedRateModel.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.4;
 
 import "../interfaces/rates/storage/IRateParamsStore.sol";
 import "../interfaces/rates/ILinearKinkedRateModel.sol";
+import "../libraries/GSMath.sol";
 import "./AbstractRateModel.sol";
 
 /// @title Linear Kinked Rate Model used to calculate the yearly rate charged to liquidity borrowers according to the current utilization rate of the pool
@@ -75,7 +76,7 @@ abstract contract LinearKinkedRateModel is AbstractRateModel, ILinearKinkedRateM
 
     /// @dev return max leverage based on optimal utilization rate times 1000 (e.g. 1000 / (1 - optimalRate)
     function _calcMaxLeverage(uint256 _optimalUtilRate) internal virtual view returns(uint256) {
-        return 1e21 / (1e18 - _optimalUtilRate);
+        return GSMath.min(1e21 / (1e18 - _optimalUtilRate), 100000); // capped at 100
     }
 
     /// @dev return spread to add to the CFMMFeeIndex as the borrow rate * 10

--- a/contracts/rates/LinearKinkedRateModel.sol
+++ b/contracts/rates/LinearKinkedRateModel.sol
@@ -105,4 +105,10 @@ abstract contract LinearKinkedRateModel is AbstractRateModel, ILinearKinkedRateM
         if(_slope2 < _slope1) revert Slope2LtSlope1();
         return true;
     }
+
+    /// @dev See {AbstractRateModel-_calcMaxLeverage}
+    function _calcMaxLeverage(address paramsStore, address pool) internal override virtual view returns(uint256) {
+        (,uint64 _optimalUtilRate,,) = getRateModelParams(paramsStore, pool);
+        return 1e21 / (1e18 - _optimalUtilRate);
+    }
 }

--- a/contracts/rates/LogDerivativeRateModel.sol
+++ b/contracts/rates/LogDerivativeRateModel.sol
@@ -61,7 +61,7 @@ abstract contract LogDerivativeRateModel is AbstractRateModel, ILogDerivativeRat
         spread = _calcSpread();
     }
 
-    /// @dev max leverage hardcoded at 5x
+    /// @dev max leverage hardcoded at 5 with 3 decimal precision
     function _calcMaxLeverage() internal virtual view returns(uint256) {
         return 5000;
     }

--- a/contracts/rates/LogDerivativeRateModel.sol
+++ b/contracts/rates/LogDerivativeRateModel.sol
@@ -54,7 +54,7 @@ abstract contract LogDerivativeRateModel is AbstractRateModel, ILogDerivativeRat
         if(utilizationRate == 0) { // if utilization rate is zero, the borrow rate is zero
             return (0, 0, maxLeverage, 1e18);
         }
-        uint256 utilizationRateSquare = utilizationRate**2; // since utilizationRate is a fraction, this lowers its value in a non linear way
+        uint256 utilizationRateSquare = GSMath.min(utilizationRate**2, 1e36); // since utilizationRate is a fraction, this lowers its value in a non linear way
         uint256 denominator = 1 + 1e36 - utilizationRateSquare; // add 1 so that it never becomes 0
         (uint64 _baseRate, uint80 _factor, uint80 _maxApy) = getRateModelParams(paramsStore, pool);
         borrowRate = GSMath.min(_baseRate + _factor * utilizationRateSquare / denominator, _maxApy); // division by an ever non linear decreasing denominator creates an exponential looking curve as util. rate increases

--- a/contracts/rates/LogDerivativeRateModel.sol
+++ b/contracts/rates/LogDerivativeRateModel.sol
@@ -92,4 +92,9 @@ abstract contract LogDerivativeRateModel is AbstractRateModel, ILogDerivativeRat
         if(_factor > 1e19 || _factor == 0) revert Factor(); // revert if factor is greater than 10 or is zero
         return true;
     }
+
+    /// @dev See {AbstractRateModel-_calcMaxLeverage}
+    function _calcMaxLeverage(address paramsStore, address pool) internal override virtual view returns(uint256) {
+        return 5000;
+    }
 }

--- a/contracts/strategies/ShortStrategy.sol
+++ b/contracts/strategies/ShortStrategy.sol
@@ -67,14 +67,14 @@ abstract contract ShortStrategy is IShortStrategy, BaseStrategy {
 
     /// @inheritdoc IShortStrategy
     function getLastFees(uint256 borrowRate, uint256 borrowedInvariant, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply,
-        uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply, uint256 lastBlockNum, uint256 lastCFMMFeeIndex) public virtual override
-        view returns(uint256 lastFeeIndex, uint256 updatedLastCFMMFeeIndex) {
+        uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply, uint256 lastBlockNum, uint256 lastCFMMFeeIndex,
+        uint256 maxCFMMFeeLeverage, uint256 spread) public virtual override view returns(uint256 lastFeeIndex, uint256 updatedLastCFMMFeeIndex) {
         lastBlockNum = block.number - lastBlockNum;
 
-        updatedLastCFMMFeeIndex = lastBlockNum > 0 ? calcCFMMFeeIndex(borrowedInvariant, lastCFMMInvariant, lastCFMMTotalSupply, prevCFMMInvariant, prevCFMMTotalSupply) * lastCFMMFeeIndex / 1e18 : 1e18;
+        updatedLastCFMMFeeIndex = lastBlockNum > 0 ? calcCFMMFeeIndex(borrowedInvariant, lastCFMMInvariant, lastCFMMTotalSupply, prevCFMMInvariant, prevCFMMTotalSupply, maxCFMMFeeLeverage) * lastCFMMFeeIndex / 1e18 : 1e18;
 
         // Calculate interest that would be charged to entire pool's liquidity debt if pool were updated in this transaction
-        lastFeeIndex = calcFeeIndex(updatedLastCFMMFeeIndex, borrowRate, lastBlockNum);
+        lastFeeIndex = calcFeeIndex(updatedLastCFMMFeeIndex, borrowRate, lastBlockNum, spread);
     }
 
     //********* Short Gamma Functions *********//

--- a/contracts/strategies/base/BaseStrategy.sol
+++ b/contracts/strategies/base/BaseStrategy.sol
@@ -111,8 +111,11 @@ abstract contract BaseStrategy is AppStorage, AbstractRateModel {
     /// @param spread - spread to add to cfmmFeeIndex
     /// @return cfmmFeeIndex - cfmmFeeIndex + spread
     function addSpread(uint256 lastCFMMFeeIndex, uint256 spread) internal virtual view returns(uint256) {
-        if(lastCFMMFeeIndex > 1e18) {
-            return (lastCFMMFeeIndex - 1e18) * spread / 1e18 + 1e18;
+        if(lastCFMMFeeIndex > 1e18 && spread > 1e18) {
+            unchecked {
+                lastCFMMFeeIndex = lastCFMMFeeIndex - 1e18;
+            }
+            return lastCFMMFeeIndex * spread / 1e18 + 1e18;
         }
         return lastCFMMFeeIndex;
     }

--- a/contracts/strategies/base/BaseStrategy.sol
+++ b/contracts/strategies/base/BaseStrategy.sol
@@ -92,7 +92,7 @@ abstract contract BaseStrategy is AppStorage, AbstractRateModel {
     function calcCFMMFeeIndex(uint256 borrowedInvariant, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply, uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply) internal virtual view returns(uint256) {
         if(lastCFMMInvariant > 0 && lastCFMMTotalSupply > 0 && prevCFMMInvariant > 0 && prevCFMMTotalSupply > 0) {
             uint256 cfmmFeeIndex = lastCFMMInvariant * prevCFMMTotalSupply * 1e18 / (prevCFMMInvariant * lastCFMMTotalSupply);
-            uint256 maxLeverage = getMaxCFMMFeeLeverage();
+            uint256 maxLeverage = 5;
             if(cfmmFeeIndex > 1e18 && borrowedInvariant > maxLeverage * prevCFMMInvariant) { // exceeds max cfmm yield leverage
                 unchecked {
                     cfmmFeeIndex = cfmmFeeIndex - 1e18;
@@ -112,11 +112,6 @@ abstract contract BaseStrategy is AppStorage, AbstractRateModel {
     /// @return cfmmFeeIndex - cfmmFeeIndex + spread
     function addSpread(uint256 lastCFMMFeeIndex, uint256 borrowRate) internal virtual view returns(uint256) {
         return lastCFMMFeeIndex;
-    }
-
-    /// @return maxCFMMLeverage - max leverage of CFMM yield
-    function getMaxCFMMFeeLeverage() internal virtual view returns(uint256) {
-        return 5;
     }
 
     /// @dev Calculate total interest rate charged by GammaPool since last update

--- a/contracts/strategies/base/BaseStrategy.sol
+++ b/contracts/strategies/base/BaseStrategy.sol
@@ -78,16 +78,16 @@ abstract contract BaseStrategy is AppStorage, AbstractRateModel {
     /// @param lastCFMMTotalSupply - current CFMM LP token supply
     /// @param prevCFMMInvariant - liquidity invariant in CFMM in previous GammaPool update
     /// @param prevCFMMTotalSupply - CFMM LP token supply in previous GammaPool update
-    /// @param maxCFMMFeeLeverage - max leverage of CFMM yield
+    /// @param maxCFMMFeeLeverage - max leverage of CFMM yield with 3 decimals. E.g. 5000 = 5
     /// @return cfmmFeeIndex - index tracking accrued fees from CFMM since last GammaPool update
     ///
     /// CFMM Fee Index = 1 + CFMM Yield = (cfmmInvariant1 / cfmmInvariant0) * (cfmmTotalSupply0 / cfmmTotalSupply1)
     ///
     /// Leverage Multiplier = (cfmmInvariant0 + borrowedInvariant) / cfmmInvariant0
     ///
-    /// Deleveraged CFMM Yield = CFMM Yield / Leverage Multiplier
+    /// Deleveraged CFMM Yield = CFMM Yield / Leverage Multiplier = CFMM Yield * prevCFMMInvariant / (prevCFMMInvariant + borrowedInvariant)
     ///
-    /// Releveraged CFMM Yield = Deleveraged CFMM Yield * Max CFMM Yield Leverage
+    /// Releveraged CFMM Yield = Deleveraged CFMM Yield * Max CFMM Yield Leverage = Deleveraged CFMM Yield * maxCFMMFeeLeverage / 1000
     ///
     /// Releveraged CFMM Fee Index = 1 + Releveraged CFMM Yield
     function calcCFMMFeeIndex(uint256 borrowedInvariant, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply, uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply, uint256 maxCFMMFeeLeverage) internal virtual view returns(uint256) {

--- a/contracts/test/rates/TestLinearKinkedRateModel.sol
+++ b/contracts/test/rates/TestLinearKinkedRateModel.sol
@@ -14,7 +14,7 @@ contract TestLinearKinkedRateModel is LinearKinkedRateModel, AbstractRateParamsS
     }
 
     function testCalcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant) public virtual view returns(uint256 borrowRate) {
-        (borrowRate,) = calcBorrowRate(lpInvariant, borrowedInvariant, paramsStore, address(this));
+        (borrowRate,,,) = calcBorrowRate(lpInvariant, borrowedInvariant, paramsStore, address(this));
     }
 
     function _rateParamsStoreOwner() internal virtual override view returns(address) {

--- a/contracts/test/rates/TestLogDerivativeRateModel.sol
+++ b/contracts/test/rates/TestLogDerivativeRateModel.sol
@@ -15,7 +15,7 @@ contract TestLogDerivativeRateModel is LogDerivativeRateModel, AbstractRateParam
     }
 
     function testCalcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant) public virtual view returns(uint256 borrowRate) {
-        (borrowRate,) = calcBorrowRate(lpInvariant, borrowedInvariant, paramsStore, address(this));
+        (borrowRate,,,) = calcBorrowRate(lpInvariant, borrowedInvariant, paramsStore, address(this));
     }
 
     function _rateParamsStoreOwner() internal virtual override view returns(address) {

--- a/contracts/test/strategies/TestERC20Strategy.sol
+++ b/contracts/test/strategies/TestERC20Strategy.sol
@@ -53,8 +53,9 @@ contract TestERC20Strategy is AppStorage, IShortStrategy {
         return s.totalSupply;
     }
 
-    function getLastFees(uint256 borrowRate, uint256 borrowedInvariant, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply, uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply, uint256 lastBlockNum, uint256 lastCFMMFeeIndex)
-        external override view returns(uint256 lastFeeIndex, uint256 updLastCFMMFeeIndex) {
+    function getLastFees(uint256 borrowRate, uint256 borrowedInvariant, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply,
+        uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply, uint256 lastBlockNum, uint256 lastCFMMFeeIndex,
+        uint256 maxCFMMFeeLeverage, uint256 spread) external override view returns(uint256 lastFeeIndex, uint256 updLastCFMMFeeIndex) {
         return (2,3);
     }
 
@@ -114,8 +115,10 @@ contract TestERC20Strategy is AppStorage, IShortStrategy {
         return 0;
     }
 
-    function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual view returns(uint256 borrowRate, uint256 utilizationRate) {
+    function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual view returns(uint256 borrowRate, uint256 utilizationRate, uint256 maxCFMMFeeLeverage, uint256 spread) {
         borrowRate = 4*1e16;
         utilizationRate = 3*1e17;
+        maxCFMMFeeLeverage = 5000;
+        spread = 1e18;
     }
 }

--- a/contracts/test/strategies/TestShortStrategy2.sol
+++ b/contracts/test/strategies/TestShortStrategy2.sol
@@ -54,8 +54,9 @@ contract TestShortStrategy2 is IShortStrategy{
         return 1000*(10**18);
     }
 
-    function getLastFees(uint256 borrowRate, uint256 borrowedInvariant, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply, uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply, uint256 lastBlockNum, uint256 lastCFMMFeeIndex)
-        external override view returns(uint256 lastFeeIndex, uint256 updLastCFMMFeeIndex) {
+    function getLastFees(uint256 borrowRate, uint256 borrowedInvariant, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply,
+        uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply, uint256 lastBlockNum, uint256 lastCFMMFeeIndex,
+        uint256 maxCFMMFeeLeverage, uint256 spread) external override view returns(uint256 lastFeeIndex, uint256 updLastCFMMFeeIndex) {
         return (2,1e18);
     }
 
@@ -64,9 +65,11 @@ contract TestShortStrategy2 is IShortStrategy{
         return (4,5,6);
     }
 
-    function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual view returns(uint256 borrowRate, uint256 utilizationRate) {
+    function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual view returns(uint256 borrowRate, uint256 utilizationRate, uint256 maxCFMMFeeLeverage, uint256 spread) {
         borrowRate = 4*1e16;
         utilizationRate = 3*1e17;
+        maxCFMMFeeLeverage = 5000;
+        spread = 1e18;
     }
 
     /***** ERC4626 Functions *****/

--- a/contracts/test/strategies/base/TestBaseShortStrategy.sol
+++ b/contracts/test/strategies/base/TestBaseShortStrategy.sol
@@ -145,10 +145,13 @@ abstract contract TestBaseShortStrategy is ShortStrategy {
         return convertToAssets(shares);
     }
 
-    function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual override view returns(uint256 borrowRate, uint256 utilizationRate) {
+    function calcBorrowRate(uint256 lpInvariant, uint256 borrowedInvariant, address paramsStore, address pool) public virtual
+        override view returns(uint256 borrowRate, uint256 utilizationRate, uint256 maxCFMMFeeLeverage, uint256 spread) {
         uint256 totalInvariant = lpInvariant + borrowedInvariant;
         utilizationRate = totalInvariant == 0 ? 0 : (borrowedInvariant * 1e18 / totalInvariant);
         borrowRate = utilizationRate;
+        maxCFMMFeeLeverage = 5000;
+        spread = 1e18;
     }
 
     //ShortGamma
@@ -189,9 +192,5 @@ abstract contract TestBaseShortStrategy is ShortStrategy {
     function _getLatestCFMMInvariant(bytes memory data) external override view virtual returns(uint256 cfmmInvariant) {
         address _cfmm = abi.decode(data, (address));
         return uint128(TestCFMM(_cfmm).invariant());
-    }
-
-    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
-        return 5000;
     }
 }

--- a/contracts/test/strategies/base/TestBaseShortStrategy.sol
+++ b/contracts/test/strategies/base/TestBaseShortStrategy.sol
@@ -190,4 +190,8 @@ abstract contract TestBaseShortStrategy is ShortStrategy {
         address _cfmm = abi.decode(data, (address));
         return uint128(TestCFMM(_cfmm).invariant());
     }
+
+    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
+        return 5000;
+    }
 }

--- a/contracts/test/strategies/base/TestBaseStrategy.sol
+++ b/contracts/test/strategies/base/TestBaseStrategy.sol
@@ -132,13 +132,13 @@ contract TestBaseStrategy is BaseStrategy {
     }
 
     function testUpdateCFMMIndex() public virtual {
-        (uint256 lastCFMMFeeIndex,,) = updateCFMMIndex(s.BORROWED_INVARIANT);
+        (uint256 lastCFMMFeeIndex,,) = updateCFMMIndex(s.BORROWED_INVARIANT, 5000);
         _lastCFMMFeeIndex = uint64(lastCFMMFeeIndex);
     }
 
     function testUpdateFeeIndex() public virtual {
-        (uint256 _borrowRate,) = calcBorrowRate(s.LP_INVARIANT, s.BORROWED_INVARIANT, s.factory, address(this));
-        _lastFeeIndex = uint80(calcFeeIndex(_lastCFMMFeeIndex, _borrowRate, block.number - s.LAST_BLOCK_NUMBER));
+        (uint256 _borrowRate,,,uint256 spread) = calcBorrowRate(s.LP_INVARIANT, s.BORROWED_INVARIANT, s.factory, address(this));
+        _lastFeeIndex = uint80(calcFeeIndex(_lastCFMMFeeIndex, _borrowRate, block.number - s.LAST_BLOCK_NUMBER, spread));
     }
 
     function testUpdateStore() public virtual {
@@ -176,12 +176,8 @@ contract TestBaseStrategy is BaseStrategy {
         return s.balanceOf[account];
     }
 
-    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256) {
-        return (borrowRate, 1e18/2);
-    }
-
-    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
-        return 5000;
+    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256, uint256, uint256) {
+        return (borrowRate, 1e18/2, 5000, 1e18);
     }
 
     function getReserves() public virtual view returns(uint128[] memory) {

--- a/contracts/test/strategies/base/TestBaseStrategy.sol
+++ b/contracts/test/strategies/base/TestBaseStrategy.sol
@@ -180,6 +180,10 @@ contract TestBaseStrategy is BaseStrategy {
         return (borrowRate, 1e18/2);
     }
 
+    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
+        return 5000;
+    }
+
     function getReserves() public virtual view returns(uint128[] memory) {
         return s.CFMM_RESERVES;
     }

--- a/contracts/test/strategies/base/TestBorrowStrategy.sol
+++ b/contracts/test/strategies/base/TestBorrowStrategy.sol
@@ -123,12 +123,8 @@ contract TestBorrowStrategy is BorrowStrategy {
         borrowRate = _borrowRate;
     }
 
-    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256) {
-        return (borrowRate,0);
-    }
-
-    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
-        return 5000;
+    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256, uint256, uint256) {
+        return (borrowRate,0,5000,1e18);
     }
 
     //LongGamma

--- a/contracts/test/strategies/base/TestBorrowStrategy.sol
+++ b/contracts/test/strategies/base/TestBorrowStrategy.sol
@@ -127,6 +127,10 @@ contract TestBorrowStrategy is BorrowStrategy {
         return (borrowRate,0);
     }
 
+    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
+        return 5000;
+    }
+
     //LongGamma
     function beforeRepay(LibStorage.Loan storage _loan, uint256[] memory amounts) internal virtual override {
         _loan.tokensHeld[0] -= uint128(amounts[0]);

--- a/contracts/test/strategies/base/TestLiquidationStrategy.sol
+++ b/contracts/test/strategies/base/TestLiquidationStrategy.sol
@@ -188,6 +188,10 @@ contract TestLiquidationStrategy is SingleLiquidationStrategy, BatchLiquidationS
         return (0,0);
     }
 
+    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
+        return 5000;
+    }
+
     //BaseStrategy functions
     function calcCFMMFeeIndex(uint256, uint256, uint256, uint256, uint256) internal override virtual view returns(uint256) {
         return 0;

--- a/contracts/test/strategies/base/TestLiquidationStrategy.sol
+++ b/contracts/test/strategies/base/TestLiquidationStrategy.sol
@@ -184,24 +184,20 @@ contract TestLiquidationStrategy is SingleLiquidationStrategy, BatchLiquidationS
     }
 
     //AbstractRateModel abstract functions
-    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256) {
-        return (0,0);
-    }
-
-    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
-        return 5000;
+    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256, uint256, uint256) {
+        return (0,0,5000,1e18);
     }
 
     //BaseStrategy functions
-    function calcCFMMFeeIndex(uint256, uint256, uint256, uint256, uint256) internal override virtual view returns(uint256) {
+    function calcCFMMFeeIndex(uint256, uint256, uint256, uint256, uint256, uint256) internal override virtual view returns(uint256) {
         return 0;
     }
 
-    function calcFeeIndex(uint256, uint256, uint256) internal override virtual view returns(uint256) {
+    function calcFeeIndex(uint256, uint256, uint256, uint256) internal override virtual view returns(uint256) {
         return 0;
     }
 
-    function updateCFMMIndex(uint256) internal override virtual returns(uint256, uint256, uint256){
+    function updateCFMMIndex(uint256, uint256) internal override virtual returns(uint256, uint256, uint256){
         return (0,0,0);
     }
 

--- a/contracts/test/strategies/base/TestLongStrategy.sol
+++ b/contracts/test/strategies/base/TestLongStrategy.sol
@@ -119,12 +119,8 @@ contract TestLongStrategy is RepayStrategy, BorrowStrategy {
         borrowRate = _borrowRate;
     }
 
-    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256) {
-        return (borrowRate,0);
-    }
-
-    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
-        return 5000;
+    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256, uint256, uint256) {
+        return (borrowRate,0,5000,1e18);
     }
 
     //LongGamma

--- a/contracts/test/strategies/base/TestLongStrategy.sol
+++ b/contracts/test/strategies/base/TestLongStrategy.sol
@@ -123,6 +123,10 @@ contract TestLongStrategy is RepayStrategy, BorrowStrategy {
         return (borrowRate,0);
     }
 
+    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
+        return 5000;
+    }
+
     //LongGamma
     function beforeRepay(LibStorage.Loan storage _loan, uint256[] memory amounts) internal virtual override {
         _loan.tokensHeld[0] -= uint128(amounts[0]);

--- a/contracts/test/strategies/base/TestRebalanceStrategy.sol
+++ b/contracts/test/strategies/base/TestRebalanceStrategy.sol
@@ -118,6 +118,10 @@ contract TestRebalanceStrategy is BorrowStrategy, RebalanceStrategy {
         return (borrowRate,0);
     }
 
+    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
+        return 5000;
+    }
+
     //LongGamma
     function beforeRepay(LibStorage.Loan storage _loan, uint256[] memory amounts) internal virtual override {
         _loan.tokensHeld[0] -= uint128(amounts[0]);

--- a/contracts/test/strategies/base/TestRebalanceStrategy.sol
+++ b/contracts/test/strategies/base/TestRebalanceStrategy.sol
@@ -114,12 +114,8 @@ contract TestRebalanceStrategy is BorrowStrategy, RebalanceStrategy {
         borrowRate = _borrowRate;
     }
 
-    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256) {
-        return (borrowRate,0);
-    }
-
-    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
-        return 5000;
+    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256, uint256, uint256) {
+        return (borrowRate,0,5000,1e18);
     }
 
     //LongGamma

--- a/contracts/test/strategies/base/TestRepayStrategy.sol
+++ b/contracts/test/strategies/base/TestRepayStrategy.sol
@@ -114,12 +114,8 @@ contract TestRepayStrategy is RepayStrategy, BorrowStrategy {
         borrowRate = _borrowRate;
     }
 
-    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256) {
-        return (borrowRate,0);
-    }
-
-    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
-        return 5000;
+    function calcBorrowRate(uint256, uint256, address, address) public virtual override view returns(uint256, uint256, uint256, uint256) {
+        return (borrowRate,0,5000,1e18);
     }
 
     //LongGamma

--- a/contracts/test/strategies/base/TestRepayStrategy.sol
+++ b/contracts/test/strategies/base/TestRepayStrategy.sol
@@ -118,6 +118,10 @@ contract TestRepayStrategy is RepayStrategy, BorrowStrategy {
         return (borrowRate,0);
     }
 
+    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
+        return 5000;
+    }
+
     //LongGamma
     function beforeRepay(LibStorage.Loan storage _loan, uint256[] memory amounts) internal virtual override {
         _loan.tokensHeld[0] -= uint128(amounts[0]);

--- a/contracts/test/strategies/external/TestExternalBaseRebalanceStrategy.sol
+++ b/contracts/test/strategies/external/TestExternalBaseRebalanceStrategy.sol
@@ -36,6 +36,10 @@ abstract contract TestExternalBaseRebalanceStrategy is BaseExternalStrategy {
         return 8000;
     }
 
+    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
+        return 5000;
+    }
+
     function minPay() internal view virtual override returns(uint256) {
         return 1e3;
     }

--- a/contracts/test/strategies/external/TestExternalBaseRebalanceStrategy.sol
+++ b/contracts/test/strategies/external/TestExternalBaseRebalanceStrategy.sol
@@ -36,10 +36,6 @@ abstract contract TestExternalBaseRebalanceStrategy is BaseExternalStrategy {
         return 8000;
     }
 
-    function _calcMaxLeverage(address paramsStore, address pool) internal virtual override view returns(uint256) {
-        return 5000;
-    }
-
     function minPay() internal view virtual override returns(uint256) {
         return 1e3;
     }
@@ -119,8 +115,8 @@ abstract contract TestExternalBaseRebalanceStrategy is BaseExternalStrategy {
         rateIndex = _loan.rateIndex;
     }
 
-    function calcBorrowRate(uint256,uint256,address, address) public virtual override view returns(uint256,uint256) {
-        return(0,0);
+    function calcBorrowRate(uint256,uint256,address, address) public virtual override view returns(uint256,uint256,uint256,uint256) {
+        return(0,0,5000,1e18);
     }
 
     function calcInvariant(address, uint128[] memory amounts) internal virtual override view returns(uint256) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "1.1.30",
+  "version": "1.2.0",
   "description": "Core smart contracts for the GammaSwap V1 protocol",
   "homepage": "https://gammaswap.com",
   "scripts": {

--- a/test/strategies/ShortStrategy.test.ts
+++ b/test/strategies/ShortStrategy.test.ts
@@ -780,7 +780,9 @@ describe("ShortStrategy", function () {
           params0.prevCFMMInvariant,
           params0.prevCFMMTotalSupply,
           params0.lastBlockNum,
-          params0.lastCFMMFeeIndex
+          params0.lastCFMMFeeIndex,
+          borrowRate.maxCFMMFeeLeverage,
+          borrowRate.spread
         );
 
         const totalAssets0 = await strategy.totalAssets(
@@ -813,7 +815,9 @@ describe("ShortStrategy", function () {
           params1.prevCFMMInvariant,
           params1.prevCFMMTotalSupply,
           params1.lastBlockNum.add(1),
-          params1.lastCFMMFeeIndex
+          params1.lastCFMMFeeIndex,
+          borrowRate1.maxCFMMFeeLeverage,
+          borrowRate1.spread
         );
         const totalAssets1 = await strategy.totalAssets(
           params1.borrowedInvariant,
@@ -927,7 +931,9 @@ describe("ShortStrategy", function () {
           params1.prevCFMMInvariant,
           params1.prevCFMMTotalSupply,
           params1.lastBlockNum.sub(2),
-          params1.lastCFMMFeeIndex
+          params1.lastCFMMFeeIndex,
+          borrowRate.maxCFMMFeeLeverage,
+          borrowRate.spread
         );
 
         const currTotalAssets = await strategy.totalAssets(
@@ -1343,7 +1349,9 @@ describe("ShortStrategy", function () {
           params1.prevCFMMInvariant,
           params1.prevCFMMTotalSupply,
           params1.lastBlockNum.sub(1),
-          params1.lastCFMMFeeIndex
+          params1.lastCFMMFeeIndex,
+          borrowRate.maxCFMMFeeLeverage,
+          borrowRate.spread
         );
 
         const currTotalAssets = await strategy.totalAssets(

--- a/test/strategies/ShortStrategyERC4626.test.ts
+++ b/test/strategies/ShortStrategyERC4626.test.ts
@@ -690,7 +690,9 @@ describe("ShortStrategyERC4626", function () {
           params1.prevCFMMInvariant,
           params1.prevCFMMTotalSupply,
           params1.lastBlockNum.sub(1),
-          params1.lastCFMMFeeIndex
+          params1.lastCFMMFeeIndex,
+          borrowRate.maxCFMMFeeLeverage,
+          borrowRate.spread
         );
 
         const currTotalAssets = await strategy.totalAssets(
@@ -969,7 +971,9 @@ describe("ShortStrategyERC4626", function () {
           params1.prevCFMMInvariant,
           params1.prevCFMMTotalSupply,
           params1.lastBlockNum.sub(1),
-          params1.lastCFMMFeeIndex
+          params1.lastCFMMFeeIndex,
+          borrowRate.maxCFMMFeeLeverage,
+          borrowRate.spread
         );
 
         const currTotalAssets = await strategy.totalAssets(
@@ -1026,7 +1030,9 @@ describe("ShortStrategyERC4626", function () {
           params2.prevCFMMInvariant,
           params2.prevCFMMTotalSupply,
           params2.lastBlockNum.sub(1),
-          params2.lastCFMMFeeIndex
+          params2.lastCFMMFeeIndex,
+          borrowRate2.maxCFMMFeeLeverage,
+          borrowRate2.spread
         );
 
         const currTotalAssets2 = await strategy.totalAssets(
@@ -1268,7 +1274,9 @@ describe("ShortStrategyERC4626", function () {
         params.prevCFMMInvariant,
         params.prevCFMMTotalSupply,
         params.lastBlockNum.sub(1),
-        params.lastCFMMFeeIndex
+        params.lastCFMMFeeIndex,
+        borrowRate.maxCFMMFeeLeverage,
+        borrowRate.spread
       );
 
       const currTotalAssets = await strategy.totalAssets(
@@ -1308,7 +1316,9 @@ describe("ShortStrategyERC4626", function () {
         params1.prevCFMMInvariant,
         params1.prevCFMMTotalSupply,
         params1.lastBlockNum.sub(1),
-        params1.lastCFMMFeeIndex
+        params1.lastCFMMFeeIndex,
+        borrowRate1.maxCFMMFeeLeverage,
+        borrowRate1.spread
       );
 
       const currTotalAssets1 = await strategy.totalAssets(
@@ -1372,7 +1382,9 @@ describe("ShortStrategyERC4626", function () {
         params.prevCFMMInvariant,
         params.prevCFMMTotalSupply,
         params.lastBlockNum.sub(1),
-        params.lastCFMMFeeIndex
+        params.lastCFMMFeeIndex,
+        borrowRate.maxCFMMFeeLeverage,
+        borrowRate.spread
       );
 
       const currTotalAssets = await strategy.totalAssets(


### PR DESCRIPTION
-add calcMaxLeverage function to rate models
-add calcSpread function to rate models
-update calcBorrowRate to also return maxCFMMFeeLeverage and spread
-update BaseStrategy to use maxCFMMFeeLeverage and spread from rate models
-update PoolViewer to use maxCFMMFeeLeverage and spread from rate models
-update ShortStrategy.getLastFees to use maxCFMMFeeLeverage and spread from rate models
-update GammaPoolERC4626 to use maxCFMMFeeLeverage and spread from rate models
-update hardhat unit tests
-decrease size of GammaPool.getLoans() by adding unchecked blocks
-update IGammaPool interface PoolData and RateData structs to take maxCFMMFeeLeverage and spread
-check LogDerivativeRateModel utilization rate^2 not > 1e36
-update comment for origination fee at 99%