### PR TITLE
feat: Move totalAssetsAndSupply logic from GammaPoolERC4626 to ShortStrategy

### DIFF
--- a/contracts/rates/LinearKinkedRateModel.sol
+++ b/contracts/rates/LinearKinkedRateModel.sol
@@ -91,7 +91,7 @@ abstract contract LinearKinkedRateModel is AbstractRateModel, ILinearKinkedRateM
     /// @return optimalUtilRate - target utilization rate of model
     /// @return slope1 - factor parameter of model
     /// @return slope2 - maxApy parameter of model
-    function getRateModelParams(address paramsStore, address pool) public view returns(uint64, uint64, uint64, uint64) {
+    function getRateModelParams(address paramsStore, address pool) public override virtual view returns(uint64, uint64, uint64, uint64) {
         IRateParamsStore.RateParams memory rateParams = IRateParamsStore(paramsStore).getRateParams(pool);
         if(!rateParams.active) {
             return (baseRate, optimalUtilRate, slope1, slope2);

--- a/contracts/test/strategies/TestERC20Strategy.sol
+++ b/contracts/test/strategies/TestERC20Strategy.sol
@@ -43,14 +43,18 @@ contract TestERC20Strategy is AppStorage, IShortStrategy {
         cfmmInvariant = 100;
     }
 
-    function totalAssets(uint256, uint256, uint256, uint256, uint256) external override view returns(uint256) {
+    function totalAssets(uint256, uint256, uint256, uint256, uint256) public override view returns(uint256) {
         (bool success, bytes memory data) = address(_cfmm).staticcall(abi.encodeWithSelector(BALANCE_OF, msg.sender));
         require(success && data.length >= 32);
         return abi.decode(data, (uint256));
     }
 
-    function totalSupply(address, address, uint256, uint256, uint256, uint256) external override view returns(uint256) {
+    function totalSupply(address, address, uint256, uint256, uint256, uint256) public override view returns(uint256) {
         return s.totalSupply;
+    }
+
+    function totalAssetsAndSupply(VaultBalancesParams memory vaultBalanceParams) external override view returns(uint256 assets, uint256 supply) {
+        return (totalAssets(0,0,0,0,0),totalSupply(address(0),address(0),0,0,0,0));
     }
 
     function getLastFees(uint256 borrowRate, uint256 borrowedInvariant, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply,

--- a/contracts/test/strategies/TestShortStrategy2.sol
+++ b/contracts/test/strategies/TestShortStrategy2.sol
@@ -54,6 +54,10 @@ contract TestShortStrategy2 is IShortStrategy{
         return 1000*(10**18);
     }
 
+    function totalAssetsAndSupply(VaultBalancesParams memory vaultBalanceParams) external override view returns(uint256 assets, uint256 supply) {
+        return (1000*(10**18),1000*(10**18));
+    }
+
     function getLastFees(uint256 borrowRate, uint256 borrowedInvariant, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply,
         uint256 prevCFMMInvariant, uint256 prevCFMMTotalSupply, uint256 lastBlockNum, uint256 lastCFMMFeeIndex,
         uint256 maxCFMMFeeLeverage, uint256 spread) external override view returns(uint256 lastFeeIndex, uint256 updLastCFMMFeeIndex) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Core smart contracts for the GammaSwap V1 protocol",
   "homepage": "https://gammaswap.com",
   "scripts": {


### PR DESCRIPTION
-move totalAssetsAndSupply() calculation logic from GammaPoolERC4626 to ShortStrategy to lower GammaPool contract size
-make LinearKinkedRateModel.getRateModelParams() virtual
-update IShortStrategy.totalSupply natspec param comments
-update unit tests