### PR TITLE
Fix: cap cfmm index

### DIFF
--- a/contracts/libraries/GSMath.sol
+++ b/contracts/libraries/GSMath.sol
@@ -13,19 +13,36 @@ library GSMath {
         z = x < y ? x : y;
     }
 
-    // Babylonian Method (https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method)
-    function sqrt(uint256 y) internal pure returns (uint256 z) {
-        unchecked {
-            if (y > 3) {
-                z = y;
-                uint256 x = y / 2 + 1;
-                while (x < z) {
-                    z = x;
-                    x = (y / x + x) / 2;
-                }
-            } else if (y != 0) {
-                z = 1;
-            }
+    /// @dev Returns the square root of `a`.
+    /// @param a number to square root
+    /// @return z square root of a
+    function sqrt(uint256 a) internal pure returns (uint256 z) {
+        if (a == 0) return 0;
+
+        assembly {
+            z := 181 // Should be 1, but this saves a multiplication later.
+
+            let r := shl(7, lt(0xffffffffffffffffffffffffffffffffff, a))
+            r := or(shl(6, lt(0xffffffffffffffffff, shr(r, a))), r)
+            r := or(shl(5, lt(0xffffffffff, shr(r, a))), r)
+            r := or(shl(4, lt(0xffffff, shr(r, a))), r)
+            z := shl(shr(1, r), z)
+
+            // Doesn't overflow since y < 2**136 after above.
+            z := shr(18, mul(z, add(shr(r, a), 65536))) // A mul() saved from z = 181.
+
+            // Given worst case multiplicative error of 2.84 above, 7 iterations should be enough.
+            z := shr(1, add(div(a, z), z))
+            z := shr(1, add(div(a, z), z))
+            z := shr(1, add(div(a, z), z))
+            z := shr(1, add(div(a, z), z))
+            z := shr(1, add(div(a, z), z))
+            z := shr(1, add(div(a, z), z))
+            z := shr(1, add(div(a, z), z))
+
+            // If x+1 is a perfect square, the Babylonian method cycles between floor(sqrt(x)) and ceil(sqrt(x)).
+            // We always return floor. Source https://en.wikipedia.org/wiki/Integer_square_root#Using_only_integer_division
+            z := sub(z, lt(div(a, z), z))
         }
     }
 }

--- a/contracts/libraries/LibStorage.sol
+++ b/contracts/libraries/LibStorage.sol
@@ -167,7 +167,7 @@ library LibStorage {
 
         self.ltvThreshold = 5; // 50 basis points
         self.liquidationFee = 25; // 25 basis points
-        self.origFee = 2;
+        self.origFee = 0;
         self.extSwapFee = 10;
 
         self.emaMultiplier = 10; // ema smoothing factor is 10/1000 = 1%

--- a/contracts/strategies/base/BaseBorrowStrategy.sol
+++ b/contracts/strategies/base/BaseBorrowStrategy.sol
@@ -96,7 +96,7 @@ abstract contract BaseBorrowStrategy is BaseLongStrategy {
 
         // Calculate borrowed liquidity invariant excluding loan origination fee
         // Irrelevant that lastCFMMInvariant and lastCFMMInvariant are overstated since their conversion rate did not change
-        uint256 liquidityBorrowedExFee = convertLPToInvariant(lpTokens, lastCFMMInvariant, lastCFMMTotalSupply);
+        uint256 liquidityBorrowedExFee = convertLPToInvariantRoundUp(lpTokens, lastCFMMInvariant, lastCFMMTotalSupply, true);
 
         liquidity = _loan.liquidity;
         uint256 initLiquidity = minBorrow(); // avoid second sload
@@ -110,7 +110,7 @@ abstract contract BaseBorrowStrategy is BaseLongStrategy {
         uint256 lpTokenOrigFee = lpTokens * _calcOriginationFee(liquidityBorrowedExFee, borrowedInvariant, s.LP_INVARIANT, s.emaUtilRate, _loan.refFee) / 10000;
 
         // Pay origination fee share as protocol revenue
-        liquidityBorrowed = convertLPToInvariant(lpTokenOrigFee, lastCFMMInvariant, lastCFMMTotalSupply);
+        liquidityBorrowed = convertLPToInvariantRoundUp(lpTokenOrigFee, lastCFMMInvariant, lastCFMMTotalSupply, true);
         mintOrigFeeToDevs(liquidityBorrowed, borrowedInvariant + s.LP_INVARIANT);
 
         // Calculate borrowed liquidity invariant including origination fee

--- a/contracts/strategies/base/BaseStrategy.sol
+++ b/contracts/strategies/base/BaseStrategy.sol
@@ -180,7 +180,18 @@ abstract contract BaseStrategy is AppStorage, AbstractRateModel {
     /// @param lastCFMMTotalSupply - total supply of LP tokens issued by CFMM
     /// @return liquidityInvariant - liquidity invariant lpTokens represents
     function convertLPToInvariant(uint256 lpTokens, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply) internal virtual pure returns(uint256) {
-        return lastCFMMTotalSupply == 0 ? 0 : (lpTokens * lastCFMMInvariant) / lastCFMMTotalSupply;
+        return convertLPToInvariantRoundUp(lpTokens, lastCFMMInvariant, lastCFMMTotalSupply, false);
+    }
+
+    /// @notice Convert CFMM LP tokens into liquidity invariant units, with option to round up
+    /// @dev In case of CFMM where convertLPToInvariant calculation is different from convertInvariantToLP
+    /// @param lpTokens - liquidity invariant borrowed in the GammaPool
+    /// @param lastCFMMInvariant - liquidity invariant in CFMM
+    /// @param lastCFMMTotalSupply - total supply of LP tokens issued by CFMM
+    /// @param roundUp - if true, round invariant up
+    /// @return liquidityInvariant - liquidity invariant lpTokens represents
+    function convertLPToInvariantRoundUp(uint256 lpTokens, uint256 lastCFMMInvariant, uint256 lastCFMMTotalSupply, bool roundUp) internal virtual pure returns(uint256) {
+        return lastCFMMTotalSupply == 0 ? 0 : ((lpTokens * lastCFMMInvariant) * 10 / lastCFMMTotalSupply + (roundUp ? 9 : 0)) / 10;
     }
 
     /// @dev Update pool invariant, LP tokens borrowed plus interest, interest rate index, and last block update

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-core",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Core smart contracts for the GammaSwap V1 protocol",
   "homepage": "https://gammaswap.com",
   "scripts": {

--- a/test/GammaPool.test.ts
+++ b/test/GammaPool.test.ts
@@ -253,7 +253,7 @@ describe("GammaPool", function () {
       expect(res3.minUtilRate1).to.equal(90);
       expect(res3.minUtilRate2).to.equal(85);
       expect(res3.feeDivisor).to.equal(2048);
-      expect(res3.origFee).to.equal(2);
+      expect(res3.origFee).to.equal(0);
       expect(res3.extSwapFee).to.equal(10);
 
       const latestBlock = await ethers.provider.getBlock("latest");
@@ -311,7 +311,7 @@ describe("GammaPool", function () {
       expect(res4.minUtilRate1).to.equal(90);
       expect(res4.minUtilRate2).to.equal(85);
       expect(res4.feeDivisor).to.equal(2048);
-      expect(res4.origFee).to.equal(2);
+      expect(res4.origFee).to.equal(0);
       expect(res4.extSwapFee).to.equal(10);
       expect(res4.ltvThreshold).to.equal(5);
       expect(res4.liquidationFee).to.equal(25);
@@ -370,7 +370,7 @@ describe("GammaPool", function () {
       expect(res5.minUtilRate1).to.equal(90);
       expect(res5.minUtilRate2).to.equal(85);
       expect(res5.feeDivisor).to.equal(2048);
-      expect(res5.origFee).to.equal(2);
+      expect(res5.origFee).to.equal(0);
       expect(res5.extSwapFee).to.equal(10);
 
       const res6 = await poolViewer.getLatestRates(gammaPool.address);
@@ -386,7 +386,7 @@ describe("GammaPool", function () {
       expect(res6.minUtilRate1).to.equal(90);
       expect(res6.minUtilRate2).to.equal(85);
       expect(res6.feeDivisor).to.equal(2048);
-      expect(res6.origFee).to.equal(2);
+      expect(res6.origFee).to.equal(0);
       expect(res6.ltvThreshold).to.equal(5);
       expect(res6.liquidationFee).to.equal(25);
 
@@ -405,7 +405,7 @@ describe("GammaPool", function () {
       expect(res7.minUtilRate1).to.equal(90);
       expect(res7.minUtilRate2).to.equal(85);
       expect(res7.feeDivisor).to.equal(2048);
-      expect(res7.origFee).to.equal(2);
+      expect(res7.origFee).to.equal(0);
       expect(res7.ltvThreshold).to.equal(5);
       expect(res7.liquidationFee).to.equal(25);
 

--- a/test/GammaPoolFactory.test.ts
+++ b/test/GammaPoolFactory.test.ts
@@ -883,7 +883,7 @@ describe("GammaPoolFactory", function () {
 
       const gammaPool = GammaPool.attach(pool);
       const resp = await gammaPool.getPoolData();
-      expect(resp.origFee).to.equal(2);
+      expect(resp.origFee).to.equal(0);
       expect(resp.extSwapFee).to.equal(10);
       expect(resp.emaMultiplier).to.equal(10);
       expect(resp.minUtilRate1).to.equal(90);
@@ -2002,7 +2002,7 @@ describe("GammaPoolFactory", function () {
 
       const gammaPool = GammaPool.attach(pool);
       const resp = await gammaPool.getPoolData();
-      expect(resp.origFee).to.equal(2);
+      expect(resp.origFee).to.equal(0);
       expect(resp.extSwapFee).to.equal(10);
       expect(resp.emaMultiplier).to.equal(10);
       expect(resp.minUtilRate1).to.equal(90);

--- a/test/strategies/external/ExternalLiquidationStrategy.test.ts
+++ b/test/strategies/external/ExternalLiquidationStrategy.test.ts
@@ -135,7 +135,7 @@ describe("ExternalLiquidationStrategy", function () {
       expect(loan.tokensHeld[1]).to.equal(amount1);
       const heldLiquidity = sqrt(amount0.mul(amount1));
       expect(loan.heldLiquidity).to.equal(heldLiquidity);
-      expect(loan.liquidity).gt(liquidity);
+      expect(loan.liquidity).to.equal(liquidity);
       expect(loan.lpTokens).to.equal(heldLiquidity.div(2));
       expect(loan.rateIndex).to.equal(ONE);
 


### PR DESCRIPTION
-Used more gas efficient sqrt function
-Changed default base origination fee to zero
-Changed liquidity invariant calculation from LP tokens to round up when borrowing liquidity
-Capped intra block growth of cfmm fee index at max uint64
